### PR TITLE
feat: 实现 Auth API 客户端核心方法 (Issue #120)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,13 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+# Python lib/ directories (but allow frontend/src/lib/)
+/lib/
+/lib64/
+# Specific Python lib paths to ignore
+venv/lib/
+env/lib/
+.venv/lib/
 parts/
 sdist/
 var/

--- a/frontend/src/lib/api/__tests__/auth-api.test.ts
+++ b/frontend/src/lib/api/__tests__/auth-api.test.ts
@@ -1,0 +1,533 @@
+/**
+ * AuthApi 单元测试
+ *
+ * 测试覆盖范围：
+ * - login() 成功场景（验证请求发送和 Token 保存）
+ * - login() 失败场景（401 错误、网络错误）
+ * - register() 成功场景（验证请求发送和 Token 保存）
+ * - register() 失败场景（400 错误、网络错误）
+ * - refreshToken() 成功场景（验证请求发送和 Token 更新）
+ * - refreshToken() 失败场景（无 refresh_token、401 错误）
+ * - getCurrentUser() 成功场景（验证请求发送）
+ * - getCurrentUser() 失败场景（401 错误）
+ *
+ * 测试状态: RED (等待实现)
+ * 依赖文件: /workspace/frontend/src/lib/api/auth-api.ts
+ *
+ * @jest-environment jsdom
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+// 注意：当前 auth-api.ts 尚未实现，这个 import 会导致测试失败
+// 这是预期的行为（TDD Red First 原则）
+// 当 task-developer 实现了 auth-api.ts 后，测试将能够正确运行
+import { AuthApi } from '../auth-api';
+import type { HttpClient } from '../client';
+import type { TokenStorage } from '@/lib/storage/token-storage';
+import type { TokenResponse, UserResponse } from '@/types/auth';
+
+// ============================================================================
+// Mock 工厂函数
+// ============================================================================
+
+/**
+ * 创建 Mock HttpClient
+ */
+const createMockHttpClient = (): HttpClient => ({
+  post: jest.fn(),
+  get: jest.fn(),
+  put: jest.fn(),
+  delete: jest.fn(),
+  request: jest.fn(),
+});
+
+/**
+ * 创建 Mock TokenStorage
+ */
+const createMockTokenStorage = (): TokenStorage => ({
+  setTokens: jest.fn(() => true),
+  getTokens: jest.fn(() => null),
+  getAccessToken: jest.fn(() => null),
+  getRefreshToken: jest.fn(() => null),
+  isTokenExpired: jest.fn(() => true),
+  clearTokens: jest.fn(() => {}),
+  hasValidTokens: jest.fn(() => false),
+});
+
+/**
+ * 创建 Mock TokenResponse
+ */
+const createMockTokenResponse = (
+  overrides?: Partial<TokenResponse>
+): TokenResponse => ({
+  access_token: 'test_access_token',
+  refresh_token: 'test_refresh_token',
+  token_type: 'Bearer',
+  expires_in: 3600,
+  ...overrides,
+});
+
+/**
+ * 创建 Mock UserResponse
+ */
+const createMockUserResponse = (
+  overrides?: Partial<UserResponse>
+): UserResponse => ({
+  id: 1,
+  username: 'testuser',
+  email: 'test@example.com',
+  is_active: true,
+  created_at: '2024-01-01T00:00:00Z',
+  ...overrides,
+});
+
+/**
+ * 创建登录响应（包含 User 和 Tokens）
+ */
+const createLoginResponse = () => ({
+  user: createMockUserResponse(),
+  ...createMockTokenResponse(),
+});
+
+// ============================================================================
+// 测试套件
+// ============================================================================
+
+describe('AuthApi', () => {
+  let mockHttpClient: HttpClient;
+  let mockTokenStorage: TokenStorage;
+  let authApi: AuthApi;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockHttpClient = createMockHttpClient();
+    mockTokenStorage = createMockTokenStorage();
+
+    authApi = new AuthApi({
+      httpClient: mockHttpClient,
+      tokenStorage: mockTokenStorage,
+    });
+  });
+
+  // ==========================================================================
+  // login() - 成功场景
+  // ==========================================================================
+
+  describe('login()', () => {
+    it('should login successfully and save tokens', async () => {
+      // Arrange
+      const username = 'testuser';
+      const password = 'password123';
+      const mockResponse = createLoginResponse();
+
+      (mockHttpClient.post as jest.Mock).mockResolvedValue(mockResponse);
+
+      // Act
+      const result = await authApi.login(username, password);
+
+      // Assert
+      // 1. 验证 HTTP 请求参数
+      expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        '/api/v1/auth/login',
+        { username, password },
+        { skipAuth: true }
+      );
+
+      // 2. 验证保存 Token
+      expect(mockTokenStorage.setTokens).toHaveBeenCalledTimes(1);
+      expect(mockTokenStorage.setTokens).toHaveBeenCalledWith({
+        access_token: mockResponse.access_token,
+        refresh_token: mockResponse.refresh_token,
+        token_type: mockResponse.token_type,
+        expires_in: mockResponse.expires_in,
+      });
+
+      // 3. 验证返回值
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should support email login', async () => {
+      // Arrange
+      const email = 'test@example.com';
+      const password = 'password123';
+      const mockResponse = createLoginResponse();
+
+      (mockHttpClient.post as jest.Mock).mockResolvedValue(mockResponse);
+
+      // Act
+      const result = await authApi.login(email, password);
+
+      // Assert
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        '/api/v1/auth/login',
+        { email, password },
+        { skipAuth: true }
+      );
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  // ==========================================================================
+  // login() - 失败场景
+  // ==========================================================================
+
+  describe('login() - Error Scenarios', () => {
+    it('should handle 401 unauthorized error', async () => {
+      // Arrange
+      const mockError = new Error('Invalid credentials');
+      (mockError as any).status = 401;
+
+      (mockHttpClient.post as jest.Mock).mockRejectedValue(mockError);
+
+      // Act & Assert
+      await expect(authApi.login('testuser', 'wrongpassword')).rejects.toThrow(
+        'Invalid credentials'
+      );
+
+      // 验证没有保存 Token
+      expect(mockTokenStorage.setTokens).not.toHaveBeenCalled();
+    });
+
+    it('should handle network error', async () => {
+      // Arrange
+      const networkError = new Error('Network error');
+      networkError.name = 'NetworkError';
+
+      (mockHttpClient.post as jest.Mock).mockRejectedValue(networkError);
+
+      // Act & Assert
+      await expect(authApi.login('testuser', 'password')).rejects.toThrow(
+        'Network error'
+      );
+
+      // 验证没有保存 Token
+      expect(mockTokenStorage.setTokens).not.toHaveBeenCalled();
+    });
+
+    it('should handle 500 server error', async () => {
+      // Arrange
+      const serverError = new Error('Internal Server Error');
+      (serverError as any).status = 500;
+
+      (mockHttpClient.post as jest.Mock).mockRejectedValue(serverError);
+
+      // Act & Assert
+      await expect(authApi.login('testuser', 'password')).rejects.toThrow(
+        'Internal Server Error'
+      );
+
+      // 验证没有保存 Token
+      expect(mockTokenStorage.setTokens).not.toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // register() - 成功场景
+  // ==========================================================================
+
+  describe('register()', () => {
+    it('should register successfully and save tokens', async () => {
+      // Arrange
+      const username = 'newuser';
+      const email = 'new@example.com';
+      const password = 'password123';
+      const mockResponse = createLoginResponse();
+
+      (mockHttpClient.post as jest.Mock).mockResolvedValue(mockResponse);
+
+      // Act
+      const result = await authApi.register(username, email, password);
+
+      // Assert
+      // 1. 验证 HTTP 请求参数
+      expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        '/api/v1/auth/register',
+        { username, email, password },
+        { skipAuth: true }
+      );
+
+      // 2. 验证保存 Token
+      expect(mockTokenStorage.setTokens).toHaveBeenCalledTimes(1);
+      expect(mockTokenStorage.setTokens).toHaveBeenCalledWith({
+        access_token: mockResponse.access_token,
+        refresh_token: mockResponse.refresh_token,
+        token_type: mockResponse.token_type,
+        expires_in: mockResponse.expires_in,
+      });
+
+      // 3. 验证返回值
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  // ==========================================================================
+  // register() - 失败场景
+  // ==========================================================================
+
+  describe('register() - Error Scenarios', () => {
+    it('should handle 400 bad request (username already exists)', async () => {
+      // Arrange
+      const mockError = new Error('Username already exists');
+      (mockError as any).status = 400;
+
+      (mockHttpClient.post as jest.Mock).mockRejectedValue(mockError);
+
+      // Act & Assert
+      await expect(
+        authApi.register('existinguser', 'test@example.com', 'password123')
+      ).rejects.toThrow('Username already exists');
+
+      // 验证没有保存 Token
+      expect(mockTokenStorage.setTokens).not.toHaveBeenCalled();
+    });
+
+    it('should handle 400 bad request (email already exists)', async () => {
+      // Arrange
+      const mockError = new Error('Email already exists');
+      (mockError as any).status = 400;
+
+      (mockHttpClient.post as jest.Mock).mockRejectedValue(mockError);
+
+      // Act & Assert
+      await expect(
+        authApi.register('newuser', 'existing@example.com', 'password123')
+      ).rejects.toThrow('Email already exists');
+
+      // 验证没有保存 Token
+      expect(mockTokenStorage.setTokens).not.toHaveBeenCalled();
+    });
+
+    it('should handle network error', async () => {
+      // Arrange
+      const networkError = new Error('Network error');
+      networkError.name = 'NetworkError';
+
+      (mockHttpClient.post as jest.Mock).mockRejectedValue(networkError);
+
+      // Act & Assert
+      await expect(
+        authApi.register('newuser', 'new@example.com', 'password123')
+      ).rejects.toThrow('Network error');
+
+      // 验证没有保存 Token
+      expect(mockTokenStorage.setTokens).not.toHaveBeenCalled();
+    });
+
+    it('should handle 500 server error', async () => {
+      // Arrange
+      const serverError = new Error('Internal Server Error');
+      (serverError as any).status = 500;
+
+      (mockHttpClient.post as jest.Mock).mockRejectedValue(serverError);
+
+      // Act & Assert
+      await expect(
+        authApi.register('newuser', 'new@example.com', 'password123')
+      ).rejects.toThrow('Internal Server Error');
+
+      // 验证没有保存 Token
+      expect(mockTokenStorage.setTokens).not.toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // refreshToken() - 成功场景
+  // ==========================================================================
+
+  describe('refreshToken()', () => {
+    it('should refresh token successfully and update tokens', async () => {
+      // Arrange
+      const oldRefreshToken = 'old_refresh_token';
+      const mockResponse = createMockTokenResponse({
+        access_token: 'new_access_token',
+        refresh_token: 'new_refresh_token',
+      });
+
+      (mockTokenStorage.getRefreshToken as jest.Mock).mockReturnValue(
+        oldRefreshToken
+      );
+      (mockHttpClient.post as jest.Mock).mockResolvedValue(mockResponse);
+
+      // Act
+      const result = await authApi.refreshToken();
+
+      // Assert
+      // 1. 验证获取旧 refresh_token
+      expect(mockTokenStorage.getRefreshToken).toHaveBeenCalledTimes(1);
+
+      // 2. 验证 HTTP 请求参数
+      expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        '/api/v1/auth/refresh',
+        { refresh_token: oldRefreshToken },
+        { skipAuth: true }
+      );
+
+      // 3. 验证保存新 Token
+      expect(mockTokenStorage.setTokens).toHaveBeenCalledTimes(1);
+      expect(mockTokenStorage.setTokens).toHaveBeenCalledWith({
+        access_token: mockResponse.access_token,
+        refresh_token: mockResponse.refresh_token,
+        token_type: mockResponse.token_type,
+        expires_in: mockResponse.expires_in,
+      });
+
+      // 4. 验证返回值
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  // ==========================================================================
+  // refreshToken() - 失败场景
+  // ==========================================================================
+
+  describe('refreshToken() - Error Scenarios', () => {
+    it('should throw error when no refresh token available', async () => {
+      // Arrange
+      (mockTokenStorage.getRefreshToken as jest.Mock).mockReturnValue(null);
+
+      // Act & Assert
+      await expect(authApi.refreshToken()).rejects.toThrow(
+        'No refresh token available'
+      );
+
+      // 验证没有发起 HTTP 请求
+      expect(mockHttpClient.post).not.toHaveBeenCalled();
+
+      // 验证没有保存 Token
+      expect(mockTokenStorage.setTokens).not.toHaveBeenCalled();
+    });
+
+    it('should handle 401 unauthorized error (expired refresh token)', async () => {
+      // Arrange
+      const mockError = new Error('Invalid refresh token');
+      (mockError as any).status = 401;
+
+      (mockTokenStorage.getRefreshToken as jest.Mock).mockReturnValue(
+        'expired_token'
+      );
+      (mockHttpClient.post as jest.Mock).mockRejectedValue(mockError);
+
+      // Act & Assert
+      await expect(authApi.refreshToken()).rejects.toThrow(
+        'Invalid refresh token'
+      );
+
+      // 验证发起了请求
+      expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
+
+      // 验证没有保存无效 Token
+      expect(mockTokenStorage.setTokens).not.toHaveBeenCalled();
+    });
+
+    it('should handle network error', async () => {
+      // Arrange
+      const networkError = new Error('Network error');
+      networkError.name = 'NetworkError';
+
+      (mockTokenStorage.getRefreshToken as jest.Mock).mockReturnValue(
+        'refresh_token'
+      );
+      (mockHttpClient.post as jest.Mock).mockRejectedValue(networkError);
+
+      // Act & Assert
+      await expect(authApi.refreshToken()).rejects.toThrow('Network error');
+
+      // 验证发起了请求
+      expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
+
+      // 验证没有保存 Token
+      expect(mockTokenStorage.setTokens).not.toHaveBeenCalled();
+    });
+
+    it('should handle 500 server error', async () => {
+      // Arrange
+      const serverError = new Error('Internal Server Error');
+      (serverError as any).status = 500;
+
+      (mockTokenStorage.getRefreshToken as jest.Mock).mockReturnValue(
+        'refresh_token'
+      );
+      (mockHttpClient.post as jest.Mock).mockRejectedValue(serverError);
+
+      // Act & Assert
+      await expect(authApi.refreshToken()).rejects.toThrow(
+        'Internal Server Error'
+      );
+
+      // 验证没有保存 Token
+      expect(mockTokenStorage.setTokens).not.toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // getCurrentUser() - 成功场景
+  // ==========================================================================
+
+  describe('getCurrentUser()', () => {
+    it('should get current user successfully', async () => {
+      // Arrange
+      const mockResponse = createMockUserResponse();
+
+      (mockHttpClient.get as jest.Mock).mockResolvedValue(mockResponse);
+
+      // Act
+      const result = await authApi.getCurrentUser();
+
+      // Assert
+      // 1. 验证 HTTP 请求参数
+      expect(mockHttpClient.get).toHaveBeenCalledTimes(1);
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/api/v1/auth/me');
+
+      // 2. 验证返回值
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  // ==========================================================================
+  // getCurrentUser() - 失败场景
+  // ==========================================================================
+
+  describe('getCurrentUser() - Error Scenarios', () => {
+    it('should handle 401 unauthorized error (not authenticated)', async () => {
+      // Arrange
+      const mockError = new Error('Not authenticated');
+      (mockError as any).status = 401;
+
+      (mockHttpClient.get as jest.Mock).mockRejectedValue(mockError);
+
+      // Act & Assert
+      await expect(authApi.getCurrentUser()).rejects.toThrow(
+        'Not authenticated'
+      );
+    });
+
+    it('should handle network error', async () => {
+      // Arrange
+      const networkError = new Error('Network error');
+      networkError.name = 'NetworkError';
+
+      (mockHttpClient.get as jest.Mock).mockRejectedValue(networkError);
+
+      // Act & Assert
+      await expect(authApi.getCurrentUser()).rejects.toThrow('Network error');
+    });
+
+    it('should handle 500 server error', async () => {
+      // Arrange
+      const serverError = new Error('Internal Server Error');
+      (serverError as any).status = 500;
+
+      (mockHttpClient.get as jest.Mock).mockRejectedValue(serverError);
+
+      // Act & Assert
+      await expect(authApi.getCurrentUser()).rejects.toThrow(
+        'Internal Server Error'
+      );
+    });
+  });
+});

--- a/frontend/src/lib/api/auth-api.ts
+++ b/frontend/src/lib/api/auth-api.ts
@@ -1,0 +1,201 @@
+/**
+ * Auth API 客户端
+ *
+ * 对应后端 API 端点：
+ * - POST /api/v1/auth/login - 用户登录
+ * - POST /api/v1/auth/register - 用户注册
+ * - POST /api/v1/auth/refresh - 刷新 Token
+ * - GET /api/v1/auth/me - 获取当前用户信息
+ *
+ * 职责：
+ * - 封装认证相关的 HTTP 请求
+ * - 自动保存 Token 到 TokenStorage
+ * - 提供类型安全的 API 接口
+ */
+
+import type { HttpClient } from './client';
+import type { TokenStorage } from '@/lib/storage/token-storage';
+import type { TokenResponse, UserResponse } from '@/types/auth';
+
+/**
+ * 登录/注册响应（包含用户信息和 Token）
+ */
+export interface AuthResponse extends UserResponse, TokenResponse {}
+
+/**
+ * AuthApi 配置
+ */
+export interface AuthApiConfig {
+  /** HTTP 客户端实例 */
+  httpClient: HttpClient;
+  /** Token 存储实例 */
+  tokenStorage: TokenStorage;
+}
+
+/**
+ * Auth API 客户端类
+ */
+export class AuthApi {
+  private httpClient: HttpClient;
+  private tokenStorage: TokenStorage;
+
+  constructor(config: AuthApiConfig) {
+    this.httpClient = config.httpClient;
+    this.tokenStorage = config.tokenStorage;
+  }
+
+  /**
+   * 用户登录
+   *
+   * 对应后端：POST /api/v1/auth/login
+   *
+   * @param usernameOrEmail - 用户名或邮箱
+   * @param password - 密码
+   * @returns 用户信息和 Token
+   * @throws {Error} 登录失败时抛出异常
+   */
+  async login(usernameOrEmail: string, password: string): Promise<AuthResponse> {
+    // 判断是用户名还是邮箱
+    const isEmail = usernameOrEmail.includes('@');
+    const payload = isEmail
+      ? { email: usernameOrEmail, password }
+      : { username: usernameOrEmail, password };
+
+    // 发送登录请求（skipAuth: true 表示不需要 Token）
+    const response = await this.httpClient.post<AuthResponse>(
+      '/api/v1/auth/login',
+      payload,
+      { skipAuth: true }
+    );
+
+    // 保存 Token
+    this.tokenStorage.setTokens({
+      access_token: response.access_token,
+      refresh_token: response.refresh_token,
+      token_type: response.token_type,
+      expires_in: response.expires_in,
+    });
+
+    return response;
+  }
+
+  /**
+   * 用户注册
+   *
+   * 对应后端：POST /api/v1/auth/register
+   *
+   * @param username - 用户名
+   * @param email - 邮箱地址
+   * @param password - 密码
+   * @returns 新创建的用户信息和 Token
+   * @throws {Error} 注册失败时抛出异常（如用户名/邮箱已存在）
+   */
+  async register(
+    username: string,
+    email: string,
+    password: string
+  ): Promise<AuthResponse> {
+    // 发送注册请求（skipAuth: true 表示不需要 Token）
+    const response = await this.httpClient.post<AuthResponse>(
+      '/api/v1/auth/register',
+      { username, email, password },
+      { skipAuth: true }
+    );
+
+    // 保存 Token
+    this.tokenStorage.setTokens({
+      access_token: response.access_token,
+      refresh_token: response.refresh_token,
+      token_type: response.token_type,
+      expires_in: response.expires_in,
+    });
+
+    return response;
+  }
+
+  /**
+   * 刷新访问令牌
+   *
+   * 对应后端：POST /api/v1/auth/refresh
+   *
+   * @returns 新的 Token
+   * @throws {Error} 无 refresh_token 或刷新失败时抛出异常
+   */
+  async refreshToken(): Promise<TokenResponse> {
+    // 获取现有的 refresh_token
+    const refreshToken = this.tokenStorage.getRefreshToken();
+    if (!refreshToken) {
+      throw new Error('No refresh token available');
+    }
+
+    // 发送刷新请求（skipAuth: true 表示不需要 Token）
+    const response = await this.httpClient.post<TokenResponse>(
+      '/api/v1/auth/refresh',
+      { refresh_token: refreshToken },
+      { skipAuth: true }
+    );
+
+    // 保存新 Token
+    this.tokenStorage.setTokens({
+      access_token: response.access_token,
+      refresh_token: response.refresh_token,
+      token_type: response.token_type,
+      expires_in: response.expires_in,
+    });
+
+    return response;
+  }
+
+  /**
+   * 获取当前用户信息
+   *
+   * 对应后端：GET /api/v1/auth/me
+   *
+   * @returns 当前用户信息
+   * @throws {Error} 未认证或请求失败时抛出异常
+   */
+  async getCurrentUser(): Promise<UserResponse> {
+    // 发送请求（需要认证，HttpClient 会自动注入 Token）
+    return this.httpClient.get<UserResponse>('/api/v1/auth/me');
+  }
+}
+
+/**
+ * 创建 AuthApi 实例的工厂函数
+ *
+ * @param config - AuthApi 配置
+ * @returns AuthApi 实例
+ */
+export function createAuthApi(config: AuthApiConfig): AuthApi {
+  return new AuthApi(config);
+}
+
+// ============================================================================
+// 单例导出（供其他模块直接使用）
+// ============================================================================
+
+/**
+ * 默认 AuthApi 实例
+ *
+ * 注意：此单例需要在应用初始化时手动配置
+ * 建议使用 createAuthApi() 创建自定义实例
+ */
+export let authApi: AuthApi | null = null;
+
+/**
+ * 设置全局 AuthApi 实例
+ *
+ * @param api - AuthApi 实例
+ */
+export function setAuthApi(api: AuthApi): void {
+  authApi = api;
+}
+
+/**
+ * 获取全局 AuthApi 实例
+ *
+ * @returns AuthApi 实例，未配置时返回 null
+ */
+export function getAuthApi(): AuthApi | null {
+  return authApi;
+}


### PR DESCRIPTION
## 概述
实现 Auth API 客户端核心方法，提供类型安全的认证 API 接口。

## 变更内容

### 新增文件
- `frontend/src/lib/api/auth-api.ts` - Auth API 客户端实现
- `frontend/src/lib/api/__tests__/auth-api.test.ts` - Auth API 单元测试

### 实现功能
1. **login(usernameOrEmail, password)** - 用户登录
   - 自动识别用户名或邮箱登录
   - 成功后自动保存 Token

2. **register(username, email, password)** - 用户注册
   - 创建新用户并返回 Token
   - 成功后自动保存 Token

3. **refreshToken()** - 刷新访问令牌
   - 使用现有 refresh_token 获取新 Token
   - 成功后自动更新 TokenStorage

4. **getCurrentUser()** - 获取当前用户信息
   - 依赖 HttpClient 自动注入 Token

### 测试覆盖
- 19 个单元测试，覆盖所有正常流程和异常场景
- Mock 策略：完全隔离 HttpClient 和 TokenStorage

### 配置修复
- 修复 `.gitignore` 中 `lib/` 规则导致前端代码被忽略的问题

## 测试计划
- [x] 所有 19 个单元测试通过
- [x] TypeScript 类型检查通过
- [ ] CI 检查通过

Closes #120

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)