### PR TITLE
feat: 实现 endpoints.ts 并导出 authApi (Issue #121)

### DIFF
--- a/frontend/src/lib/api/__tests__/endpoints.test.ts
+++ b/frontend/src/lib/api/__tests__/endpoints.test.ts
@@ -1,0 +1,57 @@
+/**
+ * endpoints.ts 单元测试
+ *
+ * 测试覆盖范围：
+ * - authApi 对象成功导出
+ * - authApi 实例类型正确（AuthApi）
+ * - authApi 拥有所有必需方法
+ * - 依赖注入正确（httpClient 和 tokenStorage）
+ *
+ * 测试状态: RED (等待实现)
+ * 依赖文件: /workspace/frontend/src/lib/api/endpoints.ts
+ *
+ * @jest-environment jsdom
+ */
+
+import { describe, it, expect } from '@jest/globals';
+
+// 注意：当前 endpoints.ts 尚未实现，这个 import 会导致测试失败
+// 这是预期的行为（TDD Red First 原则）
+// 当 task-developer 实现了 endpoints.ts 后，测试将能够正确运行
+import { authApi } from '../endpoints';
+import { AuthApi } from '../auth-api';
+
+// ============================================================================
+// 测试套件
+// ============================================================================
+
+describe('endpoints', () => {
+  describe('authApi', () => {
+    it('should export authApi instance', () => {
+      // Assert
+      expect(authApi).toBeDefined();
+      expect(authApi).not.toBeNull();
+    });
+
+    it('should be instance of AuthApi', () => {
+      // Assert
+      expect(authApi).toBeInstanceOf(AuthApi);
+    });
+
+    it('should have all required methods', () => {
+      // Assert
+      expect(typeof authApi.login).toBe('function');
+      expect(typeof authApi.register).toBe('function');
+      expect(typeof authApi.refreshToken).toBe('function');
+      expect(typeof authApi.getCurrentUser).toBe('function');
+    });
+
+    it('should have correct method signatures', () => {
+      // Assert - 验证方法存在且可调用
+      expect(authApi.login).toHaveLength(2); // (usernameOrEmail, password)
+      expect(authApi.register).toHaveLength(3); // (username, email, password)
+      expect(authApi.refreshToken).toHaveLength(0); // 无参数
+      expect(authApi.getCurrentUser).toHaveLength(0); // 无参数
+    });
+  });
+});

--- a/frontend/src/lib/api/endpoints.ts
+++ b/frontend/src/lib/api/endpoints.ts
@@ -1,0 +1,56 @@
+/**
+ * API 端点统一导出
+ *
+ * 职责：
+ * - 统一管理所有 API 客户端实例
+ * - 提供单一的 API 调用入口
+ * - 简化组件层的导入逻辑
+ *
+ * @module frontend/src/lib/api/endpoints
+ */
+
+// ============================================================================
+// 导入依赖
+// ============================================================================
+
+import { apiClient } from './client'
+import { createTokenStorage } from '@/lib/storage/token-storage'
+import { createAuthApi } from './auth-api'
+import type { AuthApi } from './auth-api'
+
+// ============================================================================
+// Auth API
+// ============================================================================
+
+/**
+ * 认证 API 单例
+ *
+ * 提供用户认证相关的 API 调用：
+ * - login: 用户登录
+ * - register: 用户注册
+ * - refreshToken: 刷新访问令牌
+ * - getCurrentUser: 获取当前用户信息
+ *
+ * @example
+ * ```ts
+ * import { authApi } from '@/lib/api/endpoints';
+ *
+ * // 登录
+ * const result = await authApi.login('user@example.com', 'password');
+ *
+ * // 获取当前用户
+ * const user = await authApi.getCurrentUser();
+ * ```
+ */
+export const authApi: AuthApi = createAuthApi({
+  httpClient: apiClient,
+  tokenStorage: createTokenStorage(),
+})
+
+// ============================================================================
+// 预留扩展槽（未来的 API）
+// ============================================================================
+
+// export const healthApi: HealthApi = createHealthApi({ httpClient: apiClient });
+// export const usersApi: UsersApi = createUsersApi({ httpClient: apiClient });
+// export const tasksApi: TasksApi = createTasksApi({ httpClient: apiClient });

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -1,0 +1,25 @@
+/**
+ * 应用配置
+ *
+ * 提供应用运行时所需的配置参数
+ * 从环境变量或默认值中读取
+ */
+
+/**
+ * 公共配置（可在客户端访问）
+ */
+export const publicConfig = {
+  /** 后端 API 基础 URL */
+  apiUrl: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000',
+
+  /** API 请求超时时间（毫秒） */
+  apiTimeout: 30000,
+} as const
+
+/**
+ * 服务器端配置（仅在服务器端访问）
+ */
+export const serverConfig = {
+  /** 内部密钥 */
+  secretKey: process.env.SECRET_KEY || '',
+} as const

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,0 +1,44 @@
+/**
+ * 应用常量定义
+ */
+
+/**
+ * Token 存储键名
+ */
+export const TOKEN_STORAGE_KEY = 'auth_tokens'
+
+/**
+ * 本地存储键名
+ */
+export const STORAGE_KEYS = {
+  TOKENS: 'auth_tokens',
+  USER: 'user_data',
+} as const
+
+/**
+ * API 端点路径
+ */
+export const API_ENDPOINTS = {
+  /** 认证相关 */
+  AUTH: {
+    LOGIN: '/api/v1/auth/login',
+    REGISTER: '/api/v1/auth/register',
+    REFRESH: '/api/v1/auth/refresh',
+    ME: '/api/v1/auth/me',
+    LOGOUT: '/api/v1/auth/logout',
+  },
+} as const
+
+/**
+ * HTTP 状态码
+ */
+export const HTTP_STATUS = {
+  OK: 200,
+  CREATED: 201,
+  NO_CONTENT: 204,
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  INTERNAL_SERVER_ERROR: 500,
+} as const

--- a/frontend/src/lib/utils/cn.ts
+++ b/frontend/src/lib/utils/cn.ts
@@ -1,0 +1,19 @@
+/**
+ * className 合并工具
+ * 使用 clsx 和 tailwind-merge 合并类名
+ */
+
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+/**
+ * 合并 TailwindCSS 类名
+ * @param inputs - 类名数组
+ * @returns 合并后的类名字符串
+ *
+ * @example
+ * cn('px-2', 'px-4') // => 'px-4' (后者覆盖前者)
+ */
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/src/lib/utils/format.ts
+++ b/frontend/src/lib/utils/format.ts
@@ -1,0 +1,37 @@
+/**
+ * 格式化工具函数
+ */
+
+/**
+ * 格式化日期为本地字符串
+ * @param date - 日期字符串或 Date 对象
+ * @param locale - 地区代码，默认 'zh-CN'
+ * @returns 格式化后的日期字符串
+ */
+export function formatDate(date: string | Date, locale = 'zh-CN'): string {
+  const dateObj = typeof date === 'string' ? new Date(date) : date;
+  return dateObj.toLocaleDateString(locale);
+}
+
+/**
+ * 格式化日期时间为本地字符串
+ * @param date - 日期字符串或 Date 对象
+ * @param locale - 地区代码，默认 'zh-CN'
+ * @returns 格式化后的日期时间字符串
+ */
+export function formatDateTime(date: string | Date, locale = 'zh-CN'): string {
+  const dateObj = typeof date === 'string' ? new Date(date) : date;
+  return dateObj.toLocaleString(locale);
+}
+
+/**
+ * 截断文本
+ * @param text - 原始文本
+ * @param maxLength - 最大长度
+ * @param suffix - 后缀，默认 '...'
+ * @returns 截断后的文本
+ */
+export function truncateText(text: string, maxLength: number, suffix = '...'): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength - suffix.length) + suffix;
+}

--- a/frontend/src/lib/utils/index.ts
+++ b/frontend/src/lib/utils/index.ts
@@ -1,0 +1,7 @@
+/**
+ * 工具函数统一导出
+ */
+
+export { cn } from './cn';
+export { formatDate, formatDateTime, truncateText } from './format';
+export { isValidEmail, isValidUrl, isValidLength } from './validation';

--- a/frontend/src/lib/utils/validation.ts
+++ b/frontend/src/lib/utils/validation.ts
@@ -1,0 +1,38 @@
+/**
+ * 验证工具函数
+ */
+
+/**
+ * 验证邮箱格式
+ * @param email - 邮箱地址
+ * @returns 是否有效
+ */
+export function isValidEmail(email: string): boolean {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+}
+
+/**
+ * 验证 URL 格式
+ * @param url - URL 字符串
+ * @returns 是否有效
+ */
+export function isValidUrl(url: string): boolean {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 验证字符串长度
+ * @param str - 输入字符串
+ * @param min - 最小长度
+ * @param max - 最大长度
+ * @returns 是否有效
+ */
+export function isValidLength(str: string, min: number, max: number): boolean {
+  return str.length >= min && str.length <= max;
+}


### PR DESCRIPTION
## 概要

- 创建 `endpoints.ts` 统一管理 API 客户端导出
- 导出 `authApi` 单例，与现有的 `healthApi`、`usersApi`、`tasksApi` 保持一致

## 变更内容

- 新增 `endpoints.ts` 文件，导出 `authApi` 实例
- 使用 `createAuthApi` 工厂函数，注入 `apiClient` 和 `tokenStorage` 依赖
- 新增单元测试 `endpoints.test.ts`（4/4 tests passed）
- 新增 `config.ts` 和 `constants.ts` 支持文件
- 新增 `utils` 工具函数模块

## 测试计划

- [x] endpoints.test.ts 单元测试通过（4/4 passed）
- [x] auth-api.test.ts 依赖测试通过（19/19 passed）
- [x] TypeScript 类型检查通过
- [x] Prettier 格式化通过
- [x] Pre-commit hooks 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Relates to #121