### PR TITLE
feat: 实现 TokenStorage.updateAccessToken() 方法 (Issue #108)

### DIFF
--- a/frontend/src/store/auth/auth-store.ts
+++ b/frontend/src/store/auth/auth-store.ts
@@ -126,9 +126,8 @@ export function createAuthStore(
           state.tokenExpiresAt = expiresAt;
         });
 
-        // 注意：这里仅更新 access_token，refresh_token 保持不变
-        // 实际实现需要考虑如何更新 storage 中的 access_token
-        // TODO: 更新 storage 中的 access_token
+        // 同步更新 Token 存储（仅更新 access_token，refresh_token 保持不变）
+        storage.updateAccessToken(accessToken, expiresIn);
       },
 
       clearAuth: () => {


### PR DESCRIPTION
## 概述

- 在 TokenStorage 接口中新增 updateAccessToken() 方法
- 实现逻辑：仅更新 access_token 和 expiresAt，保持 refresh_token 不变
- 修复 auth-store.ts 中 updateAccessToken 的 TODO

## 变更内容

### 1. TokenStorage 接口扩展
- 新增 `updateAccessToken(accessToken: string, expiresIn: number): boolean` 方法
- 用于 Token 刷新场景，保持 refresh_token 不变

### 2. auth-store.ts 修复
- 移除 TODO 注释
- 调用 `storage.updateAccessToken()` 同步更新 storage

### 3. 测试覆盖
- token-storage.test.ts: 新增 9 个测试用例
- auth-store.test.ts: 新增 1 个 storage 同步测试

## 测试结果

- token-storage.test.ts: 50/50 通过
- auth-store.test.ts: 62/62 通过

## 验收标准

- [x] 移除 auth-store.ts 中的 TODO 注释
- [x] TokenStorage.updateAccessToken() 正确实现
- [x] Storage 和 Store 状态保持同步
- [x] 测试覆盖率 >= 90