### PR TITLE
feat: 实现 useAuth Hook (Issue #141)

### DIFF
--- a/BLUEPRINT_ISSUE_141.md
+++ b/BLUEPRINT_ISSUE_141.md
@@ -1,0 +1,483 @@
+# useAuth Hook 架构蓝图 (Issue #141)
+
+> **文档版本**: 1.0
+> **创建日期**: 2026-02-28
+> **状态**: 设计完成，待实现
+
+---
+
+## 1. 需求概述
+
+### 1.1 任务目标
+创建 `useAuth` Hook，为 React 组件提供全局认证状态查询和操作接口。
+
+### 1.2 核心功能
+1. 创建 `frontend/src/lib/hooks/useAuth.ts`
+2. 封装全局认证状态查询接口
+3. 集成 `SessionManager`，提供自动刷新能力
+4. 提供登出、刷新等操作方法
+5. 编写单元测试（任务 #142 负责集成测试）
+
+### 1.3 设计原则
+- **KISS 原则**: 保持代码简洁，直接暴露 `authStore` 的状态
+- **一致性**: 遵循现有 hooks 的代码风格（`useApi.ts`, `useLocalStorage.ts`）
+- **SSR 安全**: 检查 `window` 是否存在，避免服务端渲染错误
+- **单一职责**: 仅作为 `authStore` 的 React 层适配器，不包含业务逻辑
+
+---
+
+## 2. 接口定义
+
+### 2.1 TypeScript 类型
+
+```typescript
+/**
+ * useAuth Hook 返回值类型
+ */
+export interface UseAuthResult {
+  // ========== 状态查询 ==========
+  /** 认证状态（'authenticated' | 'unauthenticated' | 'loading'） */
+  status: AuthStatus;
+  /** 当前用户信息（已认证时存在） */
+  user: UserResponse | null;
+  /** 是否已认证（便捷属性） */
+  isAuthenticated: boolean;
+  /** 是否正在认证 */
+  isAuthenticating: boolean;
+  /** 认证错误（如果存在） */
+  error: AuthError | null;
+
+  // ========== 操作方法 ==========
+  /** 刷新访问令牌（调用 AuthClient） */
+  refreshToken: () => Promise<TokenResponse>;
+  /** 登出（清除认证状态） */
+  logout: (options?: LogoutOptions) => Promise<void>;
+  /** 清除认证错误 */
+  clearError: () => void;
+}
+
+/**
+ * useAuth Hook 配置选项（预留，当前版本不使用） */
+export interface UseAuthOptions {
+  /** 是否自动启动 SessionManager（默认 true） */
+  autoStartSessionManager?: boolean;
+  /** SessionManager 实例（可选，用于测试） */
+  sessionManager?: import('@/lib/auth/session-manager').SessionManager;
+}
+```
+
+### 2.2 函数签名
+
+```typescript
+/**
+ * useAuth Hook - React 层认证状态管理
+ *
+ * 职责：
+ * - 订阅 authStore 状态变化
+ * - 提供便捷的认证操作方法
+ * - 集成 SessionManager 实现自动刷新
+ * - 保证 SSR 安全性
+ *
+ * @param options - 配置选项（可选）
+ * @returns UseAuthResult 认证状态与操作方法
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { isAuthenticated, user, logout } = useAuth();
+ *
+ *   if (!isAuthenticated) {
+ *     return <LoginButton />;
+ *   }
+ *
+ *   return (
+ *     <div>
+ *       Welcome, {user.username}!
+ *       <button onClick={logout}>Logout</button>
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useAuth(options?: UseAuthOptions): UseAuthResult {
+  // Implementation pending
+}
+```
+
+---
+
+## 3. 模块集成
+
+### 3.1 依赖模块
+
+| 模块 | 用途 | 集成方式 |
+|------|------|----------|
+| `authStore` | 认证状态存储 | Zustand `useStore` hook 订阅 |
+| `SessionManager` | Token 自动刷新 | Hook 内部单例管理 |
+| `AuthClient` | Token 刷新和登出 | 调用 `authClient` 方法 |
+| `TokenStorage` | Token 读取 | 通过 `AuthClient` 间接访问 |
+
+### 3.2 状态流向
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        React Component                          │
+│                                                                 │
+│   const { isAuthenticated, user, logout } = useAuth()          │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                         useAuth Hook                            │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │  const authStore = useAuthStore()                          │ │
+│  │  const sessionManager = useSessionManager()                │ │
+│  │                                                            │ │
+│  │  return {                                                  │ │
+│  │    status: authStore.status,                               │ │
+│  │    user: authStore.user,                                   │ │
+│  │    isAuthenticated: status === 'authenticated',            │ │
+│  │    logout: () => authClient.logout(),                      │ │
+│  │    refreshToken: () => authClient.refreshToken(),          │ │
+│  │  }                                                         │ │
+│  └────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+          ┌───────────────────┼───────────────────┐
+          │                   │                   │
+          ▼                   ▼                   ▼
+┌─────────────────┐  ┌──────────────────┐  ┌──────────────────┐
+│   authStore     │  │ SessionManager   │  │  AuthClient      │
+│  (Zustand)      │  │  (单例管理)      │  │  (API 调用)      │
+│                 │  │                  │  │                  │
+│ - status        │  │ - start()        │  │ - refreshToken() │
+│ - user          │  │ - stop()         │  │ - logout()       │
+│ - error         │  │                  │  │                  │
+└─────────────────┘  └──────────────────┘  └──────────────────┘
+```
+
+### 3.3 SessionManager 生命周期
+
+```typescript
+// 全局单例 SessionManager（延迟初始化）
+let sessionManagerInstance: SessionManager | null = null;
+
+function getSessionManager(): SessionManager {
+  if (sessionManagerInstance) {
+    return sessionManagerInstance;
+  }
+
+  if (typeof window === 'undefined') {
+    // SSR 环境返回 Mock（避免服务端错误）
+    return createMockSessionManager();
+  }
+
+  sessionManagerInstance = createSessionManager({
+    tokenStorage: createTokenStorage(),
+    authClient: authClient,
+    authStore: authStore,
+  });
+
+  return sessionManagerInstance;
+}
+```
+
+---
+
+## 4. 错误处理策略
+
+### 4.1 错误来源
+
+| 错误来源 | 处理方式 |
+|----------|----------|
+| `refreshToken()` 失败 | 由 `SessionManager` 处理，401 自动登出 |
+| `logout()` 失败 | 记录警告，不影响本地状态清除 |
+| 网络错误 | 由 `AuthClient` 抛出，调用者决定处理方式 |
+
+### 4.2 错误传播
+
+```typescript
+// useAuth Hook 不吞没错误，允许调用者处理
+export function useAuth(): UseAuthResult {
+  const refreshToken = useCallback(async () => {
+    try {
+      return await authClient.refreshToken();
+    } catch (error) {
+      // 重新抛出，由调用者决定是否显示 Toast
+      throw error;
+    }
+  }, []);
+
+  const logout = useCallback(async (options?: LogoutOptions) => {
+    try {
+      await authClient.logout(options);
+    } catch (error) {
+      // logout 失败不影响本地状态清除，但记录警告
+      console.warn('Logout API failed:', error);
+    }
+  }, []);
+
+  return { refreshToken, logout };
+}
+```
+
+---
+
+## 5. SSR 兼容性方案
+
+### 5.1 问题分析
+
+- `authStore` 在 SSR 环境下不存在
+- `SessionManager` 依赖 `window` 和 `setTimeout`
+- 需要避免服务端渲染时访问浏览器 API
+
+### 5.2 解决方案
+
+```typescript
+// 方案 1: 检测浏览器环境
+const isBrowser = typeof window !== 'undefined';
+
+// 方案 2: 延迟初始化 SessionManager
+function useAuth(options?: UseAuthOptions): UseAuthResult {
+  const authStore = useAuthStore();
+
+  // 仅在浏览器环境启动 SessionManager
+  useEffect(() => {
+    if (isBrowser) {
+      const manager = getSessionManager();
+      manager.start();
+
+      return () => manager.stop();
+    }
+  }, []);
+
+  // ... 其余逻辑
+}
+
+// 方案 3: 提供默认状态（SSR 场景）
+const defaultState: UseAuthResult = {
+  status: 'loading',
+  user: null,
+  isAuthenticated: false,
+  isAuthenticating: false,
+  error: null,
+  refreshToken: async () => { throw new Error('Not available in SSR'); },
+  logout: async () => {},
+  clearError: () => {},
+};
+```
+
+---
+
+## 6. 文件结构
+
+```
+frontend/src/lib/hooks/
+├── __tests__/
+│   └── useAuth.test.ts           # 单元测试（本任务）
+├── useApi.ts                     # 现有文件（参考）
+├── useLocalStorage.ts            # 现有文件（参考）
+└── useAuth.ts                    # 新建文件（本任务）
+```
+
+---
+
+## 7. 测试要求（任务 #142 集成测试）
+
+### 7.1 单元测试范围（本任务）
+
+```typescript
+describe('useAuth', () => {
+  it('应该返回正确的认证状态', () => {
+    // 测试 isAuthenticated、user 等状态
+  });
+
+  it('应该调用 logout 并清除状态', () => {
+    // 测试 logout 方法
+  });
+
+  it('应该调用 refreshToken 并更新 Token', () => {
+    // 测试 refreshToken 方法
+  });
+
+  it('应该在组件挂载时启动 SessionManager', () => {
+    // 测试 SessionManager 集成
+  });
+
+  it('应该在组件卸载时停止 SessionManager', () => {
+    // 测试清理逻辑
+  });
+
+  it('SSR 环境下不应该抛出错误', () => {
+    // 测试 SSR 兼容性
+  });
+});
+```
+
+### 7.2 集成测试范围（任务 #142）
+
+- 与登录流程的端到端集成
+- Token 自动刷新的完整流程
+- 多组件共享认证状态的一致性
+
+---
+
+## 8. 实现检查清单
+
+- [ ] 创建 `frontend/src/lib/hooks/useAuth.ts`
+- [ ] 定义 `UseAuthResult` 和 `UseAuthOptions` 类型
+- [ ] 实现 `useAuth` Hook 函数
+- [ ] 集成 `authStore`（使用 `useAuthStore()`）
+- [ ] 集成 `SessionManager`（单例模式）
+- [ ] 实现 `logout` 方法
+- [ ] 实现 `refreshToken` 方法
+- [ ] 实现 `clearError` 方法
+- [ ] 添加 SSR 安全检查
+- [ ] 编写单元测试 `frontend/src/lib/hooks/__tests__/useAuth.test.ts`
+- [ ] 更新导出 `frontend/src/lib/hooks/index.ts`（如果存在）
+
+---
+
+## 9. 依赖关系
+
+### 9.1 前置依赖
+
+- ✅ `authStore` (`frontend/src/store/auth/auth-store.ts`) - 已完成
+- ✅ `SessionManager` (`frontend/src/lib/auth/session-manager.ts`) - 已完成
+- ✅ `AuthClient` (`frontend/src/lib/api/auth-client.ts`) - 已完成
+
+### 9.2 后续依赖
+
+- 任务 #142: SessionManager 与 useAuth Hook 集成测试与文档完善
+
+---
+
+## 10. 风险与注意事项
+
+| 风险 | 影响 | 缓解措施 |
+|------|------|----------|
+| SessionManager 重复启动 | 内存泄漏 | 使用单例模式，确保只有一个实例 |
+| SSR 渲染报错 | 应用崩溃 | 添加 `typeof window` 检查 |
+| logout 网络失败 | 用户状态不一致 | 无论 API 成功与否都清除本地状态 |
+| 多个组件同时调用 refreshToken | 重复请求 | SessionManager 内部已实现请求去重 |
+
+---
+
+## 11. 测试策略（架构指导）
+
+### 11.1 测试方案选择
+
+**推荐方案：方案 A - 依赖注入 + jest.mock() 混合模式**
+
+基于项目现有测试模式分析，采用混合策略：
+
+| 场景 | 策略 | 原因 |
+|------|------|------|
+| 全局模块 mock | `jest.mock()` | 与项目现有测试风格一致（见 `session-manager.test.ts`） |
+| 测试数据控制 | `UseAuthOptions` 依赖注入 | 支持测试隔离，避免测试间相互影响 |
+| SSR 测试 | 环境变量模拟 | 覆盖边界情况 |
+
+### 11.2 UseAuthOptions 接口扩展
+
+```typescript
+/**
+ * useAuth Hook 配置选项
+ * 支持依赖注入，便于测试
+ */
+export interface UseAuthOptions {
+  /** 是否自动启动 SessionManager（默认 true） */
+  autoStartSessionManager?: boolean;
+  /** SessionManager 实例（可选，用于测试） */
+  sessionManager?: SessionManager;
+  /** AuthClient 实例（可选，用于测试） */
+  authClient?: AuthClient;
+  /** AuthStore 实例（可选，用于测试） */
+  authStore?: AuthStore;
+}
+```
+
+### 11.3 测试模式示例
+
+```typescript
+// 1. 全局模块 Mock（与项目风格一致）
+jest.mock('@/store/auth/auth-store', () => ({
+  authStore: mockAuthStore,
+  createAuthStore: jest.fn(() => mockAuthStore),
+}));
+
+jest.mock('@/lib/auth/session-manager', () => ({
+  createSessionManager: jest.fn(() => mockSessionManager),
+}));
+
+jest.mock('@/lib/api/auth-client', () => ({
+  authClient: {
+    refreshToken: mockRefreshToken,
+    logout: mockLogout,
+  },
+}));
+
+// 2. 测试中使用 UseAuthOptions 注入 mock
+it('应该返回正确的认证状态', () => {
+  const customStore = createMockAuthStore();
+  customStore.setAuthUser(MOCK_USER, 'token', 'refresh', 3600);
+
+  const { result } = renderHook(() =>
+    useAuth({ authStore: customStore as any })
+  );
+
+  expect(result.current.isAuthenticated).toBe(true);
+});
+```
+
+### 11.4 为什么不采用纯依赖注入？
+
+| 方案 | 优点 | 缺点 | 决策 |
+|------|------|------|------|
+| A) 纯依赖注入 | 完全解耦，测试隔离 | 增加生产代码复杂度；与现有风格不一致 | ❌ 不推荐 |
+| B) 纯 jest.mock() | 生产代码简洁 | 测试间可能相互影响；Mock 状态管理复杂 | ⚠️ 部分场景可用 |
+| **C) 混合模式** | **兼顾简洁性和可测试性** | **需要维护两套机制** | ✅ **推荐** |
+
+### 11.5 测试编写规范
+
+```typescript
+// ✅ 推荐写法：使用 UseAuthOptions 控制测试数据
+describe('useAuth Hook', () => {
+  it('应该返回正确的认证状态', () => {
+    const localAuthStore = createMockAuthStore();
+    localAuthStore.setAuthUser(MOCK_USER, 'token', 'refresh', 3600);
+
+    const { result } = renderHook(() =>
+      useAuth({ authStore: localAuthStore as any })
+    );
+
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+});
+
+// ✅ 推荐写法：测试全局默认行为
+describe('useAuth Hook - 默认行为', () => {
+  it('应该使用全局 authStore', () => {
+    // 不传入 options，测试默认行为
+    const { result } = renderHook(() => useAuth());
+    // 验证使用的是全局 mock
+  });
+});
+```
+
+---
+
+## 12. 附录
+
+### 12.1 参考文档
+
+- [Zustand 官方文档](https://github.com/pmndrs/zustand)
+- [React Hooks 规则](https://react.dev/reference/react)
+- [Jest Mock 最佳实践](https://jestjs.io/docs/mock-functions)
+- Issue #141: [feat: 实现 useAuth Hook（React 层认证状态）](https://github.com/...)
+
+### 12.2 代码风格参考
+
+- `frontend/src/lib/hooks/useApi.ts` - API 状态管理模式
+- `frontend/src/lib/hooks/useLocalStorage.ts` - SSR 安全处理
+- `frontend/src/store/auth/auth-store.ts` - Zustand Store 结构
+- `frontend/src/lib/auth/__tests__/session-manager.test.ts` - 测试模式参考

--- a/frontend/src/lib/hooks/__tests__/useAuth.test.ts
+++ b/frontend/src/lib/hooks/__tests__/useAuth.test.ts
@@ -1,0 +1,599 @@
+/**
+ * useAuth Hook 单元测试
+ *
+ * 测试契约:
+ * - 返回正确的认证状态
+ * - SSR 环境下安全返回初始状态
+ * - logout() 方法正确调用
+ * - refreshToken() 方法正确调用
+ * - Hook 卸载时正确停止 SessionManager
+ * - SessionManager 仅启动一次
+ * - 认证状态变化时正确更新
+ *
+ * @jest-environment jsdom
+ */
+
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { renderHook, act } from '@testing-library/react';
+import { useAuth } from '../useAuth';
+import { createAuthStore } from '@/store/auth/auth-store';
+import type { AuthStore } from '@/store/auth/auth-store-types';
+import type { SessionManager } from '@/lib/auth/session-manager';
+import type { TokenStorage } from '@/lib/storage/token-storage';
+import type { UserResponse, TokenResponse, AuthError } from '@/types/auth';
+
+// ============================================================================
+// Mock 数据
+// ============================================================================
+
+const MOCK_USER: UserResponse = {
+  id: 1,
+  username: 'testuser',
+  email: 'test@example.com',
+  is_active: true,
+  created_at: '2024-01-01T00:00:00Z',
+};
+
+const MOCK_TOKEN_RESPONSE: TokenResponse = {
+  access_token: 'mock-access-token',
+  refresh_token: 'mock-refresh-token',
+  token_type: 'Bearer',
+  expires_in: 3600,
+};
+
+const MOCK_AUTH_ERROR: AuthError = {
+  type: 'INVALID_CREDENTIALS' as const,
+  message: 'Invalid credentials',
+};
+
+// ============================================================================
+// Mock 工厂函数
+// ============================================================================
+
+const createMockTokenStorage = (): TokenStorage => ({
+  setTokens: jest.fn(() => true),
+  getTokens: jest.fn(() => null),
+  getAccessToken: jest.fn(() => null),
+  getRefreshToken: jest.fn(() => null),
+  isTokenExpired: jest.fn(() => true),
+  clearTokens: jest.fn(() => {}),
+  hasValidTokens: jest.fn(() => false),
+  updateAccessToken: jest.fn(() => true),
+});
+
+const createMockAuthClient = () => ({
+  refreshToken: jest.fn(async () => MOCK_TOKEN_RESPONSE),
+  logout: jest.fn(async () => {}),
+});
+
+const createMockSessionManager = (): SessionManager => ({
+  start: jest.fn(async () => {}),
+  stop: jest.fn(() => {}),
+  getStatus: jest.fn(() => 'idle' as const),
+} as unknown as SessionManager);
+
+// ============================================================================
+// 测试套件
+// ============================================================================
+
+describe('useAuth Hook', () => {
+  let localAuthStore: AuthStore;
+  let mockTokenStorage: TokenStorage;
+  let mockAuthClient: ReturnType<typeof createMockAuthClient>;
+  let originalWindow: Window & typeof globalThis;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // 保存原始 window 对象
+    originalWindow = global.window as Window & typeof globalThis;
+
+    // 创建本地依赖
+    mockTokenStorage = createMockTokenStorage();
+    mockAuthClient = createMockAuthClient();
+    localAuthStore = createAuthStore({
+      persist: false,
+      tokenStorage: mockTokenStorage,
+    });
+
+    // 重置状态
+    localAuthStore.getState().reset();
+  });
+
+  afterEach(() => {
+    // 清理
+    localAuthStore.getState().reset();
+
+    // 恢复 window
+    global.window = originalWindow;
+  });
+
+  // ============================================================================
+  // 基础功能测试
+  // ============================================================================
+
+  describe('基础功能', () => {
+    it('应该返回初始未认证状态', () => {
+      const mockSessionManager = createMockSessionManager();
+
+      const { result } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      expect(result.current.status).toBe('unauthenticated');
+      expect(result.current.isAuthenticated).toBe(false);
+      expect(result.current.user).toBeNull();
+      expect(result.current.isAuthenticating).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('应该返回已认证状态', () => {
+      localAuthStore.getState().setAuthUser(
+        MOCK_USER,
+        MOCK_TOKEN_RESPONSE.access_token,
+        MOCK_TOKEN_RESPONSE.refresh_token,
+        MOCK_TOKEN_RESPONSE.expires_in
+      );
+
+      const mockSessionManager = createMockSessionManager();
+
+      const { result } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      expect(result.current.status).toBe('authenticated');
+      expect(result.current.isAuthenticated).toBe(true);
+      expect(result.current.user).toEqual(MOCK_USER);
+      expect(result.current.isAuthenticating).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('应该返回认证中的状态', () => {
+      localAuthStore.getState().setLoading();
+
+      const mockSessionManager = createMockSessionManager();
+
+      const { result } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      expect(result.current.status).toBe('loading');
+      expect(result.current.isAuthenticated).toBe(false);
+      expect(result.current.isAuthenticating).toBe(true);
+    });
+
+    it('应该返回认证错误状态', () => {
+      localAuthStore.getState().setError(MOCK_AUTH_ERROR);
+
+      const mockSessionManager = createMockSessionManager();
+
+      const { result } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      expect(result.current.status).toBe('unauthenticated');
+      expect(result.current.error).toEqual(MOCK_AUTH_ERROR);
+    });
+
+    it('isAuthenticated 应该基于 status 计算', () => {
+      const mockSessionManager = createMockSessionManager();
+
+      // 未认证状态
+      const { result: result1 } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+      expect(result1.current.isAuthenticated).toBe(false);
+
+      // 已认证状态
+      localAuthStore.getState().setAuthUser(
+        MOCK_USER,
+        MOCK_TOKEN_RESPONSE.access_token,
+        MOCK_TOKEN_RESPONSE.refresh_token,
+        MOCK_TOKEN_RESPONSE.expires_in
+      );
+
+      const { result: result2 } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+      expect(result2.current.isAuthenticated).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // logout() 方法测试
+  // ============================================================================
+
+  describe('logout() 方法', () => {
+    it('应该调用 AuthClient.logout()', async () => {
+      const mockSessionManager = createMockSessionManager();
+
+      const { result } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      await act(async () => {
+        await result.current.logout();
+      });
+
+      expect(mockAuthClient.logout).toHaveBeenCalled();
+    });
+
+    it('应该支持带选项的 logout', async () => {
+      const mockSessionManager = createMockSessionManager();
+
+      const { result } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      await act(async () => {
+        await result.current.logout({ silent: true });
+      });
+
+      expect(mockAuthClient.logout).toHaveBeenCalledWith({ silent: true });
+    });
+
+    it('logout 失败时应记录警告但不抛出错误', async () => {
+      const error = new Error('Network error');
+      mockAuthClient.logout.mockRejectedValue(error);
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      const mockSessionManager = createMockSessionManager();
+
+      const { result } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      // 调用 logout 应该不抛出错误
+      await act(async () => {
+        await result.current.logout();
+      });
+
+      expect(consoleSpy).toHaveBeenCalledWith('Logout API failed:', error);
+
+      consoleSpy.mockRestore();
+    });
+
+    it('多次调用 logout 应该安全执行', async () => {
+      const mockSessionManager = createMockSessionManager();
+
+      const { result } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      await act(async () => {
+        await result.current.logout();
+        await result.current.logout();
+      });
+
+      expect(mockAuthClient.logout).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ============================================================================
+  // refreshToken() 方法测试
+  // ============================================================================
+
+  describe('refreshToken() 方法', () => {
+    it('应该调用 AuthClient.refreshToken() 并返回新 Token', async () => {
+      const mockSessionManager = createMockSessionManager();
+
+      const { result } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      let tokenResponse: TokenResponse | undefined;
+
+      await act(async () => {
+        tokenResponse = await result.current.refreshToken();
+      });
+
+      expect(mockAuthClient.refreshToken).toHaveBeenCalled();
+      expect(tokenResponse).toEqual(MOCK_TOKEN_RESPONSE);
+    });
+
+    it('refreshToken 失败时应该抛出错误', async () => {
+      const error = new Error('Refresh failed');
+      mockAuthClient.refreshToken.mockRejectedValue(error);
+
+      const mockSessionManager = createMockSessionManager();
+
+      const { result } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      await expect(async () => {
+        await act(async () => {
+          await result.current.refreshToken();
+        });
+      }).rejects.toThrow('Refresh failed');
+    });
+  });
+
+  // ============================================================================
+  // clearError() 方法测试
+  // ============================================================================
+
+  describe('clearError() 方法', () => {
+    it('应该清除认证错误', () => {
+      localAuthStore.getState().setError(MOCK_AUTH_ERROR);
+
+      const mockSessionManager = createMockSessionManager();
+
+      const { result } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      expect(result.current.error).toEqual(MOCK_AUTH_ERROR);
+
+      act(() => {
+        result.current.clearError();
+      });
+
+      expect(result.current.error).toBeNull();
+    });
+
+    it('clearError 无错误时调用应该安全', () => {
+      const mockSessionManager = createMockSessionManager();
+
+      const { result } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      expect(() => {
+        act(() => {
+          result.current.clearError();
+        });
+      }).not.toThrow();
+    });
+  });
+
+  // ============================================================================
+  // SessionManager 集成测试
+  // ============================================================================
+
+  describe('SessionManager 集成', () => {
+    it('应该在组件挂载时启动 SessionManager', () => {
+      const mockSessionManager = createMockSessionManager();
+
+      const { unmount } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      expect(mockSessionManager.start).toHaveBeenCalledTimes(1);
+
+      unmount();
+    });
+
+    it('应该在组件卸载时停止 SessionManager', () => {
+      const mockSessionManager = createMockSessionManager();
+
+      const { unmount } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      unmount();
+
+      expect(mockSessionManager.stop).toHaveBeenCalledTimes(1);
+    });
+
+    it('应该支持禁用自动启动 SessionManager', () => {
+      const mockSessionManager = createMockSessionManager();
+
+      renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+          autoStartSessionManager: false,
+        })
+      );
+
+      expect(mockSessionManager.start).not.toHaveBeenCalled();
+    });
+  });
+
+  // ============================================================================
+  // 状态同步测试
+  // ============================================================================
+
+  describe('状态同步', () => {
+    it('认证状态变化时应该更新', () => {
+      const mockSessionManager = createMockSessionManager();
+
+      const { result } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      expect(result.current.status).toBe('unauthenticated');
+      expect(result.current.isAuthenticated).toBe(false);
+
+      act(() => {
+        localAuthStore.getState().setAuthUser(
+          MOCK_USER,
+          MOCK_TOKEN_RESPONSE.access_token,
+          MOCK_TOKEN_RESPONSE.refresh_token,
+          MOCK_TOKEN_RESPONSE.expires_in
+        );
+      });
+
+      expect(result.current.status).toBe('authenticated');
+      expect(result.current.isAuthenticated).toBe(true);
+      expect(result.current.user).toEqual(MOCK_USER);
+    });
+
+    it('用户信息变化时应该更新', () => {
+      const mockSessionManager = createMockSessionManager();
+
+      const newUser: UserResponse = {
+        ...MOCK_USER,
+        username: 'newuser',
+        email: 'new@example.com',
+      };
+
+      const { result } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      act(() => {
+        localAuthStore.getState().setAuthUser(
+          newUser,
+          MOCK_TOKEN_RESPONSE.access_token,
+          MOCK_TOKEN_RESPONSE.refresh_token,
+          MOCK_TOKEN_RESPONSE.expires_in
+        );
+      });
+
+      expect(result.current.user?.username).toBe('newuser');
+      expect(result.current.user?.email).toBe('new@example.com');
+    });
+
+    it('错误状态变化时应该更新', () => {
+      const mockSessionManager = createMockSessionManager();
+
+      const { result } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      expect(result.current.error).toBeNull();
+
+      act(() => {
+        localAuthStore.getState().setError(MOCK_AUTH_ERROR);
+      });
+
+      expect(result.current.error).toEqual(MOCK_AUTH_ERROR);
+
+      act(() => {
+        localAuthStore.getState().clearError();
+      });
+
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  // ============================================================================
+  // 边界情况测试
+  // ============================================================================
+
+  describe('边界情况', () => {
+    it('多次渲染应该返回稳定的引用', () => {
+      const mockSessionManager = createMockSessionManager();
+
+      const { result, rerender } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      const firstLogout = result.current.logout;
+      const firstClearError = result.current.clearError;
+
+      rerender();
+
+      // 由于 useCallback 的依赖，引用应该保持稳定
+      expect(result.current.logout).toBe(firstLogout);
+      expect(result.current.clearError).toBe(firstClearError);
+    });
+
+    it('Hook 卸载后再挂载应该正常工作', () => {
+      const mockSessionManager = createMockSessionManager();
+
+      const { unmount } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      unmount();
+
+      const { result } = renderHook(() =>
+        useAuth({
+          sessionManager: mockSessionManager,
+          authClient: mockAuthClient as any,
+          authStore: localAuthStore as any,
+        })
+      );
+
+      expect(result.current.status).toBe('unauthenticated');
+    });
+  });
+});

--- a/frontend/src/lib/hooks/useAuth.ts
+++ b/frontend/src/lib/hooks/useAuth.ts
@@ -1,0 +1,258 @@
+/**
+ * useAuth Hook - React 层认证状态管理
+ *
+ * 职责：
+ * - 订阅 authStore 状态变化
+ * - 提供便捷的认证操作方法
+ * - 集成 SessionManager 实现自动刷新
+ * - 保证 SSR 安全性
+ *
+ * @depends
+ * - zustand (useStore hook)
+ * - @/store/auth/auth-store (authStore)
+ * - @/lib/auth/session-manager (SessionManager)
+ * - @/lib/api/auth-client (AuthClient)
+ * - @/lib/storage/token-storage (TokenStorage)
+ */
+
+import { useCallback, useEffect } from 'react';
+import { useStore } from 'zustand';
+import { authStore } from '@/store/auth/auth-store';
+import type { AuthStore } from '@/store/auth/auth-store-types';
+import { createSessionManager } from '@/lib/auth/session-manager';
+import type { SessionManager } from '@/lib/auth/session-manager';
+import { authClient } from '@/lib/api/auth-client';
+import type { AuthClient, LogoutOptions } from '@/lib/api/auth-client';
+import { createTokenStorage } from '@/lib/storage/token-storage';
+import type { TokenStorage } from '@/lib/storage/token-storage';
+import type { AuthStatus, UserResponse, AuthError, TokenResponse } from '@/types/auth';
+
+// ============================================================================
+// 类型定义
+// ============================================================================
+
+/**
+ * useAuth Hook 返回值类型
+ */
+export interface UseAuthResult {
+  // ========== 状态查询 ==========
+  /** 认证状态（'authenticated' | 'unauthenticated' | 'loading'） */
+  status: AuthStatus;
+  /** 当前用户信息（已认证时存在） */
+  user: UserResponse | null;
+  /** 是否已认证（便捷属性） */
+  isAuthenticated: boolean;
+  /** 是否正在认证 */
+  isAuthenticating: boolean;
+  /** 认证错误（如果存在） */
+  error: AuthError | null;
+
+  // ========== 操作方法 ==========
+  /** 刷新访问令牌（调用 AuthClient） */
+  refreshToken: () => Promise<TokenResponse>;
+  /** 登出（清除认证状态） */
+  logout: (options?: LogoutOptions) => Promise<void>;
+  /** 清除认证错误 */
+  clearError: () => void;
+}
+
+/**
+ * useAuth Hook 配置选项
+ */
+export interface UseAuthOptions {
+  /** 是否自动启动 SessionManager（默认 true） */
+  autoStartSessionManager?: boolean;
+  /** SessionManager 实例（可选，用于测试） */
+  sessionManager?: SessionManager;
+  /** AuthClient 实例（可选，用于测试） */
+  authClient?: typeof authClient;
+  /** AuthStore 实例（可选，用于测试） */
+  authStore?: typeof authStore;
+}
+
+// ============================================================================
+// SessionManager 单例管理
+// ============================================================================
+
+/**
+ * 全局 SessionManager 实例（延迟初始化）
+ *
+ * 设计原则：
+ * - 单例模式：确保整个应用只有一个 SessionManager 实例
+ * - 延迟初始化：仅在首次调用时创建
+ * - SSR 安全：服务端环境返回 null
+ */
+let sessionManagerInstance: SessionManager | null = null;
+
+/**
+ * 获取 SessionManager 单例
+ *
+ * @returns SessionManager 实例，SSR 环境返回 null
+ */
+function getSessionManager(): SessionManager | null {
+  // 如果已存在实例，直接返回
+  if (sessionManagerInstance) {
+    return sessionManagerInstance;
+  }
+
+  // SSR 环境不创建 SessionManager
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  // 创建新实例
+  sessionManagerInstance = createSessionManager({
+    tokenStorage: createTokenStorage(),
+    authClient: authClient,
+    authStore: authStore as AuthStore,
+  });
+
+  return sessionManagerInstance;
+}
+
+// ============================================================================
+// useAuth Hook 实现
+// ============================================================================
+
+/**
+ * useAuth Hook - React 层认证状态管理
+ *
+ * 功能：
+ * - 订阅 authStore 状态变化，自动同步到组件
+ * - 提供便捷的认证操作方法（logout、refreshToken、clearError）
+ * - 集成 SessionManager 实现自动 Token 刷新
+ * - 保证 SSR 安全性
+ *
+ * @param options - 配置选项（可选）
+ * @returns UseAuthResult 认证状态与操作方法
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { isAuthenticated, user, logout } = useAuth();
+ *
+ *   if (!isAuthenticated) {
+ *     return <LoginButton />;
+ *   }
+ *
+ *   return (
+ *     <div>
+ *       Welcome, {user.username}!
+ *       <button onClick={logout}>Logout</button>
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useAuth(options?: UseAuthOptions): UseAuthResult {
+  const {
+    autoStartSessionManager = true,
+    sessionManager: customSessionManager,
+    authClient: customAuthClient = authClient,
+    authStore: customAuthStore = authStore,
+  } = options || {};
+
+  // 使用 Zustand 的 useStore hook 订阅 authStore
+  // 这会自动在状态变化时触发组件重新渲染
+  const status = useStore(customAuthStore, (state) => state.status);
+  const user = useStore(customAuthStore, (state) => state.user);
+  const error = useStore(customAuthStore, (state) => state.error);
+  const isAuthenticating = useStore(customAuthStore, (state) => state.isAuthenticating);
+
+  // 计算便捷属性
+  const isAuthenticated = status === 'authenticated';
+
+  // 获取 SessionManager 实例（使用自定义实例或单例）
+  const sessionManager = customSessionManager ?? getSessionManager();
+
+  // ============================================================================
+  // SessionManager 生命周期管理
+  // ============================================================================
+
+  useEffect(() => {
+    // 仅在浏览器环境且启用自动启动时管理 SessionManager
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (!autoStartSessionManager || !sessionManager) {
+      return;
+    }
+
+    // 启动 SessionManager（开始自动刷新）
+    sessionManager.start();
+
+    // 清理函数：组件卸载时停止 SessionManager
+    return () => {
+      sessionManager.stop();
+    };
+  }, [sessionManager, autoStartSessionManager]);
+
+  // ============================================================================
+  // 操作方法
+  // ============================================================================
+
+  /**
+   * 刷新访问令牌
+   *
+   * 直接调用 AuthClient.refreshToken()
+   * 错误会向上传播，由调用者决定如何处理
+   */
+  const refreshToken = useCallback(async (): Promise<TokenResponse> => {
+    // SSR 环境抛出错误
+    if (typeof window === 'undefined') {
+      throw new Error('refreshToken is not available in SSR environment');
+    }
+
+    return await customAuthClient.refreshToken();
+  }, [customAuthClient]);
+
+  /**
+   * 登出（清除认证状态）
+   *
+   * 调用 AuthClient.logout()
+   * 即使 API 失败，本地状态也会被清除
+   */
+  const logout = useCallback(async (options?: LogoutOptions): Promise<void> => {
+    // SSR 环境静默返回
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      await customAuthClient.logout(options);
+    } catch (err) {
+      // logout API 失败不影响本地状态清除
+      // AuthClient 内部已经处理了状态清除
+      console.warn('Logout API failed:', err);
+    }
+  }, [customAuthClient]);
+
+  /**
+   * 清除认证错误
+   *
+   * 直接调用 authStore.clearError()
+   */
+  const clearError = useCallback((): void => {
+    // Zustand store 的方法通过 getState() 访问
+    customAuthStore.getState().clearError();
+  }, [customAuthStore]);
+
+  // ============================================================================
+  // 返回值
+  // ============================================================================
+
+  return {
+    // 状态查询
+    status,
+    user,
+    isAuthenticated,
+    isAuthenticating,
+    error,
+
+    // 操作方法
+    refreshToken,
+    logout,
+    clearError,
+  };
+}


### PR DESCRIPTION
## 概要
实现 React 认证状态管理 Hook，提供全局认证状态查询和操作接口。

## 功能特性
- 返回认证状态（status, user, isAuthenticated, isAuthenticating, error）
- 提供 logout() 和 refreshToken() 方法
- 集成 SessionManager 实现自动 Token 刷新
- 支持 SSR 兼容性检查
- 支持 UseAuthOptions 依赖注入（用于测试）

## 测试覆盖
- 21 个单元测试全部通过
- 覆盖基础功能、logout、refreshToken、SessionManager 集成、状态同步、边界情况

## 测试计划
- [x] 单元测试通过 (21/21)
- [x] 代码符合项目风格规范
- [x] 无 TypeScript 类型错误

Relates to #141

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)