### PR TITLE
feat: 创建 E2E 测试认证辅助工具 (Issue #158)

### DIFF
--- a/frontend/e2e/helpers/__tests__/auth-helpers.spec.ts
+++ b/frontend/e2e/helpers/__tests__/auth-helpers.spec.ts
@@ -1,0 +1,365 @@
+/**
+ * auth-helpers.spec.ts
+ *
+ * E2E 测试辅助函数单元测试
+ *
+ * 测试目标：验证 auth-helpers.ts 中的所有辅助函数行为
+ *
+ * 测试原则：
+ * - RED FIRST：这些测试在实现代码完成前运行应该是失败的
+ * - 简单性：测试代码逻辑简单，断言清晰
+ * - 独立性：每个测试用例独立运行，不依赖其他测试
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  registerUser,
+  loginUser,
+  logoutUser,
+  clearAuth,
+  waitForAuthState,
+  getAuthState,
+  type UserCredentials,
+  type LoginCredentials,
+} from '../auth-helpers';
+
+// ============================================================================
+// 测试数据常量
+// ============================================================================
+
+const VALID_CREDENTIALS: UserCredentials = {
+  username: 'testuser',
+  email: 'test@example.com',
+  password: 'TestPassword123!',
+};
+
+const VALID_LOGIN_CREDENTIALS: LoginCredentials = {
+  usernameOrEmail: 'testuser',
+  password: 'TestPassword123!',
+};
+
+// ============================================================================
+// registerUser 测试
+// ============================================================================
+
+test.describe('registerUser', () => {
+  test('应该成功注册用户并返回凭据', async ({ page }) => {
+    const result = await registerUser(page, VALID_CREDENTIALS);
+
+    expect(result).toEqual(VALID_CREDENTIALS);
+  });
+
+  test('注册后默认自动登录', async ({ page }) => {
+    await registerUser(page, VALID_CREDENTIALS);
+
+    const authState = await getAuthState(page);
+    expect(authState).toBe('authenticated');
+  });
+
+  test('注册时 autoLogin=false 不自动登录', async ({ page }) => {
+    await registerUser(page, VALID_CREDENTIALS, { autoLogin: false });
+
+    const authState = await getAuthState(page);
+    expect(authState).toBe('unauthenticated');
+  });
+
+  test('注册时 verifyUserInfo=false 跳过用户信息验证', async ({ page }) => {
+    const result = await registerUser(page, VALID_CREDENTIALS, {
+      verifyUserInfo: false,
+    });
+
+    expect(result).toEqual(VALID_CREDENTIALS);
+  });
+
+  test('注册后导航离开注册页面', async ({ page }) => {
+    await registerUser(page, VALID_CREDENTIALS);
+
+    expect(page.url()).not.toContain('/register');
+  });
+
+  test('注册时支持自定义超时时间', async ({ page }) => {
+    await registerUser(page, VALID_CREDENTIALS, { timeout: 5000 });
+
+    const authState = await getAuthState(page);
+    expect(authState).toBe('authenticated');
+  });
+});
+
+// ============================================================================
+// loginUser 测试
+// ============================================================================
+
+test.describe('loginUser', () => {
+  test('应该成功登录用户', async ({ page }) => {
+    const result = await loginUser(page, VALID_LOGIN_CREDENTIALS);
+
+    expect(result).toEqual(VALID_LOGIN_CREDENTIALS);
+  });
+
+  test('登录后默认验证认证状态', async ({ page }) => {
+    await loginUser(page, VALID_LOGIN_CREDENTIALS);
+
+    const authState = await getAuthState(page);
+    expect(authState).toBe('authenticated');
+  });
+
+  test('登录时 verifyAuth=false 跳过状态验证', async ({ page }) => {
+    const result = await loginUser(page, VALID_LOGIN_CREDENTIALS, {
+      verifyAuth: false,
+    });
+
+    expect(result).toEqual(VALID_LOGIN_CREDENTIALS);
+  });
+
+  test('登录时支持自定义超时时间', async ({ page }) => {
+    await loginUser(page, VALID_LOGIN_CREDENTIALS, { timeout: 5000 });
+
+    const authState = await getAuthState(page);
+    expect(authState).toBe('authenticated');
+  });
+
+  test('支持使用邮箱登录', async ({ page }) => {
+    await loginUser(page, {
+      usernameOrEmail: 'test@example.com',
+      password: 'TestPassword123!',
+    });
+
+    const authState = await getAuthState(page);
+    expect(authState).toBe('authenticated');
+  });
+});
+
+// ============================================================================
+// logoutUser 测试
+// ============================================================================
+
+test.describe('logoutUser', () => {
+  test('应该成功登出用户', async ({ page }) => {
+    // 先登录
+    await loginUser(page, VALID_LOGIN_CREDENTIALS);
+
+    // 登出
+    await logoutUser(page);
+
+    const authState = await getAuthState(page);
+    expect(authState).toBe('unauthenticated');
+  });
+
+  test('登出后默认验证未认证状态', async ({ page }) => {
+    await loginUser(page, VALID_LOGIN_CREDENTIALS);
+    await logoutUser(page, { verifyUnauth: true });
+
+    const authState = await getAuthState(page);
+    expect(authState).toBe('unauthenticated');
+  });
+
+  test('登出时 verifyUnauth=false 跳过状态验证', async ({ page }) => {
+    await loginUser(page, VALID_LOGIN_CREDENTIALS);
+    await logoutUser(page, { verifyUnauth: false });
+
+    // 不抛出错误即视为成功
+    expect(true).toBe(true);
+  });
+
+  test('登出时支持自定义超时时间', async ({ page }) => {
+    await loginUser(page, VALID_LOGIN_CREDENTIALS);
+    await logoutUser(page, { timeout: 5000 });
+
+    const authState = await getAuthState(page);
+    expect(authState).toBe('unauthenticated');
+  });
+});
+
+// ============================================================================
+// clearAuth 测试
+// ============================================================================
+
+test.describe('clearAuth', () => {
+  test('应该清除所有认证状态', async ({ page }) => {
+    // 先登录
+    await loginUser(page, VALID_LOGIN_CREDENTIALS);
+
+    // 清除认证
+    await clearAuth(page);
+
+    const authState = await getAuthState(page);
+    expect(authState).toBe('unauthenticated');
+  });
+
+  test('清除认证时默认清除所有存储', async ({ page }) => {
+    await loginUser(page, VALID_LOGIN_CREDENTIALS);
+
+    await clearAuth(page);
+
+    // 验证 localStorage 被清除
+    const tokens = await page.evaluate(() => {
+      return localStorage.getItem('auth_tokens');
+    });
+    expect(tokens).toBeNull();
+  });
+
+  test('清除时 clearLocalStorage=false 保留 localStorage', async ({ page }) => {
+    await loginUser(page, VALID_LOGIN_CREDENTIALS);
+
+    // 设置一些额外的 localStorage 数据
+    await page.evaluate(() => {
+      localStorage.setItem('other_key', 'other_value');
+    });
+
+    await clearAuth(page, { clearLocalStorage: false });
+
+    // 其他数据应该保留
+    const otherValue = await page.evaluate(() => {
+      return localStorage.getItem('other_key');
+    });
+    expect(otherValue).toBe('other_value');
+  });
+
+  test('清除时 clearCookies=false 保留 cookies', async ({ page }) => {
+    await loginUser(page, VALID_LOGIN_CREDENTIALS);
+
+    await clearAuth(page, { clearCookies: false });
+
+    // Cookies 中的认证信息应该保留
+    const cookies = await page.context().cookies();
+    const authCookie = cookies.find((c) => c.name.includes('auth'));
+    expect(authCookie).toBeDefined();
+  });
+
+  test('清除时 clearSessionStorage=true 清除 sessionStorage', async ({ page }) => {
+    await loginUser(page, VALID_LOGIN_CREDENTIALS);
+
+    await clearAuth(page, { clearSessionStorage: true });
+
+    const sessionData = await page.evaluate(() => {
+      return sessionStorage.length;
+    });
+    expect(sessionData).toBe(0);
+  });
+});
+
+// ============================================================================
+// waitForAuthState 测试
+// ============================================================================
+
+test.describe('waitForAuthState', () => {
+  test('应该等待认证状态变为 authenticated', async ({ page }) => {
+    // 后台登录（不等待）
+    page.goto('/login').then(() => {
+      page.locator('input[name="username"]').fill(VALID_LOGIN_CREDENTIALS.usernameOrEmail);
+      page.locator('input[name="password"]').fill(VALID_LOGIN_CREDENTIALS.password);
+      page.locator('button[type="submit"]').click();
+    });
+
+    const isAuth = await waitForAuthState(page, {
+      expectedStatus: 'authenticated',
+      timeout: 10000,
+    });
+
+    expect(isAuth).toBe(true);
+  });
+
+  test('应该等待认证状态变为 unauthenticated', async ({ page }) => {
+    // 先登录
+    await loginUser(page, VALID_LOGIN_CREDENTIALS);
+
+    // 后台登出
+    logoutUser(page);
+
+    const isUnauth = await waitForAuthState(page, {
+      expectedStatus: 'unauthenticated',
+      timeout: 5000,
+    });
+
+    expect(isUnauth).toBe(true);
+  });
+
+  test('等待超时时返回 false', async ({ page }) => {
+    // 不进行任何操作，状态不会改变
+    const isAuth = await waitForAuthState(page, {
+      expectedStatus: 'authenticated',
+      timeout: 1000,
+    });
+
+    expect(isAuth).toBe(false);
+  });
+
+  test('支持自定义轮询间隔', async ({ page }) => {
+    await loginUser(page, VALID_LOGIN_CREDENTIALS);
+
+    const isAuth = await waitForAuthState(page, {
+      expectedStatus: 'authenticated',
+      timeout: 5000,
+      interval: 500,
+    });
+
+    expect(isAuth).toBe(true);
+  });
+});
+
+// ============================================================================
+// getAuthState 测试
+// ============================================================================
+
+test.describe('getAuthState', () => {
+  test('未登录时返回 unauthenticated', async ({ page }) => {
+    const state = await getAuthState(page);
+
+    expect(state).toBe('unauthenticated');
+  });
+
+  test('登录后返回 authenticated', async ({ page }) => {
+    await loginUser(page, VALID_LOGIN_CREDENTIALS);
+
+    const state = await getAuthState(page);
+
+    expect(state).toBe('authenticated');
+  });
+
+  test('登出后返回 unauthenticated', async ({ page }) => {
+    await loginUser(page, VALID_LOGIN_CREDENTIALS);
+    await logoutUser(page);
+
+    const state = await getAuthState(page);
+
+    expect(state).toBe('unauthenticated');
+  });
+});
+
+// ============================================================================
+// 完整流程测试
+// ============================================================================
+
+test.describe('完整认证流程', () => {
+  test('注册 -> 登出 -> 登录 -> 登出', async ({ page }) => {
+    // 注册
+    const credentials = await registerUser(page, VALID_CREDENTIALS);
+    expect(credentials).toEqual(VALID_CREDENTIALS);
+
+    // 登出
+    await logoutUser(page);
+    expect(await getAuthState(page)).toBe('unauthenticated');
+
+    // 登录
+    await loginUser(page, VALID_LOGIN_CREDENTIALS);
+    expect(await getAuthState(page)).toBe('authenticated');
+
+    // 登出
+    await logoutUser(page);
+    expect(await getAuthState(page)).toBe('unauthenticated');
+  });
+
+  test('清除认证后重新登录', async ({ page }) => {
+    // 登录
+    await loginUser(page, VALID_LOGIN_CREDENTIALS);
+    expect(await getAuthState(page)).toBe('authenticated');
+
+    // 强制清除
+    await clearAuth(page);
+    expect(await getAuthState(page)).toBe('unauthenticated');
+
+    // 重新登录
+    await loginUser(page, VALID_LOGIN_CREDENTIALS);
+    expect(await getAuthState(page)).toBe('authenticated');
+  });
+});

--- a/frontend/e2e/helpers/__tests__/constants.spec.ts
+++ b/frontend/e2e/helpers/__tests__/constants.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * constants.spec.ts
+ *
+ * 认证辅助工具常量测试
+ *
+ * 测试目标：验证常量定义的正确性和完整性
+ *
+ * 测试原则：
+ * - RED FIRST：这些测试在实现代码完成前运行应该是失败的
+ * - 简单性：直接验证常量值
+ * - 独立性：每个测试用例独立运行
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  AUTH_SELECTORS,
+  STORAGE_KEYS,
+  DEFAULT_TIMEOUTS,
+} from '../auth-helpers';
+
+// ============================================================================
+// AUTH_SELECTORS 测试
+// ============================================================================
+
+test.describe('AUTH_SELECTORS', () => {
+  test('应该定义登录按钮选择器', () => {
+    expect(AUTH_SELECTORS.LOGIN_BUTTON).toBeDefined();
+    expect(AUTH_SELECTORS.LOGIN_BUTTON).toContain('href="/login"');
+  });
+
+  test('应该定义注册按钮选择器', () => {
+    expect(AUTH_SELECTORS.REGISTER_BUTTON).toBeDefined();
+    expect(AUTH_SELECTORS.REGISTER_BUTTON).toContain('href="/register"');
+  });
+
+  test('应该定义登出按钮选择器', () => {
+    expect(AUTH_SELECTORS.LOGOUT_BUTTON).toBeDefined();
+    expect(AUTH_SELECTORS.LOGOUT_BUTTON).toMatch(/登出|退出|logout/);
+  });
+
+  test('应该定义用户名输入框选择器', () => {
+    expect(AUTH_SELECTORS.USERNAME_INPUT).toBeDefined();
+    expect(AUTH_SELECTORS.USERNAME_INPUT).toMatch(/username/);
+  });
+
+  test('应该定义邮箱输入框选择器', () => {
+    expect(AUTH_SELECTORS.EMAIL_INPUT).toBeDefined();
+    expect(AUTH_SELECTORS.EMAIL_INPUT).toMatch(/email/);
+  });
+
+  test('应该定义密码输入框选择器', () => {
+    expect(AUTH_SELECTORS.PASSWORD_INPUT).toBeDefined();
+    expect(AUTH_SELECTORS.PASSWORD_INPUT).toMatch(/password/);
+  });
+
+  test('应该定义提交按钮选择器', () => {
+    expect(AUTH_SELECTORS.SUBMIT_BUTTON).toBeDefined();
+    expect(AUTH_SELECTORS.SUBMIT_BUTTON).toMatch(/submit|btn-primary/);
+  });
+
+  test('应该定义用户信息选择器', () => {
+    expect(AUTH_SELECTORS.USER_INFO).toBeDefined();
+    expect(AUTH_SELECTORS.USER_INFO).toMatch(/user-info/);
+  });
+
+  test('应该定义错误消息选择器', () => {
+    expect(AUTH_SELECTORS.ERROR_MESSAGE).toBeDefined();
+    expect(AUTH_SELECTORS.ERROR_MESSAGE).toMatch(/error/);
+  });
+
+  test('选择器应该是只读的', () => {
+    // 验证常量不可被修改
+    const originalValue = AUTH_SELECTORS.LOGIN_BUTTON;
+    expect(() => {
+      (AUTH_SELECTORS as any).LOGIN_BUTTON = 'modified';
+    }).not.toThrow();
+    expect(AUTH_SELECTORS.LOGIN_BUTTON).toBe(originalValue);
+  });
+});
+
+// ============================================================================
+// STORAGE_KEYS 测试
+// ============================================================================
+
+test.describe('STORAGE_KEYS', () => {
+  test('应该定义 TOKENS 存储键', () => {
+    expect(STORAGE_KEYS.TOKENS).toBeDefined();
+    expect(STORAGE_KEYS.TOKENS).toBe('auth_tokens');
+  });
+
+  test('应该定义 AUTH_STATE 存储键', () => {
+    expect(STORAGE_KEYS.AUTH_STATE).toBeDefined();
+    expect(STORAGE_KEYS.AUTH_STATE).toBe('auth-state');
+  });
+
+  test('存储键应该是字符串类型', () => {
+    expect(typeof STORAGE_KEYS.TOKENS).toBe('string');
+    expect(typeof STORAGE_KEYS.AUTH_STATE).toBe('string');
+  });
+
+  test('存储键应该是只读的', () => {
+    const originalTokens = STORAGE_KEYS.TOKENS;
+    expect(() => {
+      (STORAGE_KEYS as any).TOKENS = 'modified';
+    }).not.toThrow();
+    expect(STORAGE_KEYS.TOKENS).toBe(originalTokens);
+  });
+});
+
+// ============================================================================
+// DEFAULT_TIMEOUTS 测试
+// ============================================================================
+
+test.describe('DEFAULT_TIMEOUTS', () => {
+  test('应该定义 NAVIGATION 超时时间', () => {
+    expect(DEFAULT_TIMEOUTS.NAVIGATION).toBeDefined();
+    expect(DEFAULT_TIMEOUTS.NAVIGATION).toBe(30000);
+  });
+
+  test('应该定义 ACTION 超时时间', () => {
+    expect(DEFAULT_TIMEOUTS.ACTION).toBeDefined();
+    expect(DEFAULT_TIMEOUTS.ACTION).toBe(10000);
+  });
+
+  test('应该定义 WAIT_STATE 超时时间', () => {
+    expect(DEFAULT_TIMEOUTS.WAIT_STATE).toBeDefined();
+    expect(DEFAULT_TIMEOUTS.WAIT_STATE).toBe(5000);
+  });
+
+  test('应该定义 POLL_INTERVAL 轮询间隔', () => {
+    expect(DEFAULT_TIMEOUTS.POLL_INTERVAL).toBeDefined();
+    expect(DEFAULT_TIMEOUTS.POLL_INTERVAL).toBe(200);
+  });
+
+  test('超时时间应该是数字类型', () => {
+    expect(typeof DEFAULT_TIMEOUTS.NAVIGATION).toBe('number');
+    expect(typeof DEFAULT_TIMEOUTS.ACTION).toBe('number');
+    expect(typeof DEFAULT_TIMEOUTS.WAIT_STATE).toBe('number');
+    expect(typeof DEFAULT_TIMEOUTS.POLL_INTERVAL).toBe('number');
+  });
+
+  test('超时时间应该是正整数', () => {
+    expect(DEFAULT_TIMEOUTS.NAVIGATION).toBeGreaterThan(0);
+    expect(DEFAULT_TIMEOUTS.ACTION).toBeGreaterThan(0);
+    expect(DEFAULT_TIMEOUTS.WAIT_STATE).toBeGreaterThan(0);
+    expect(DEFAULT_TIMEOUTS.POLL_INTERVAL).toBeGreaterThan(0);
+  });
+
+  test('NAVIGATION 超时应该大于 ACTION 超时', () => {
+    expect(DEFAULT_TIMEOUTS.NAVIGATION).toBeGreaterThan(DEFAULT_TIMEOUTS.ACTION);
+  });
+
+  test('POLL_INTERVAL 应该小于 WAIT_STATE', () => {
+    expect(DEFAULT_TIMEOUTS.POLL_INTERVAL).toBeLessThan(DEFAULT_TIMEOUTS.WAIT_STATE);
+  });
+
+  test('超时时间应该是只读的', () => {
+    const originalNavTimeout = DEFAULT_TIMEOUTS.NAVIGATION;
+    expect(() => {
+      (DEFAULT_TIMEOUTS as any).NAVIGATION = 999999;
+    }).not.toThrow();
+    expect(DEFAULT_TIMEOUTS.NAVIGATION).toBe(originalNavTimeout);
+  });
+});

--- a/frontend/e2e/helpers/__tests__/errors.spec.ts
+++ b/frontend/e2e/helpers/__tests__/errors.spec.ts
@@ -1,0 +1,256 @@
+/**
+ * errors.spec.ts
+ *
+ * 认证辅助工具错误处理测试
+ *
+ * 测试目标：验证错误类型和错误处理逻辑
+ *
+ * 测试原则：
+ * - RED FIRST：这些测试在实现代码完成前运行应该是失败的
+ * - 简单性：直接验证错误类型和属性
+ * - 独立性：每个测试用例独立运行
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  AuthHelperError,
+  AuthHelperErrorType,
+} from '../auth-helpers';
+
+// ============================================================================
+// AuthHelperErrorType 枚举测试
+// ============================================================================
+
+test.describe('AuthHelperErrorType', () => {
+  test('应该定义 NAVIGATION_FAILED 错误类型', () => {
+    expect(AuthHelperErrorType.NAVIGATION_FAILED).toBeDefined();
+    expect(AuthHelperErrorType.NAVIGATION_FAILED).toBe('NAVIGATION_FAILED');
+  });
+
+  test('应该定义 ELEMENT_NOT_FOUND 错误类型', () => {
+    expect(AuthHelperErrorType.ELEMENT_NOT_FOUND).toBeDefined();
+    expect(AuthHelperErrorType.ELEMENT_NOT_FOUND).toBe('ELEMENT_NOT_FOUND');
+  });
+
+  test('应该定义 TIMEOUT 错误类型', () => {
+    expect(AuthHelperErrorType.TIMEOUT).toBeDefined();
+    expect(AuthHelperErrorType.TIMEOUT).toBe('TIMEOUT');
+  });
+
+  test('应该定义 AUTH_STATE_MISMATCH 错误类型', () => {
+    expect(AuthHelperErrorType.AUTH_STATE_MISMATCH).toBeDefined();
+    expect(AuthHelperErrorType.AUTH_STATE_MISMATCH).toBe('AUTH_STATE_MISMATCH');
+  });
+
+  test('应该定义 FORM_SUBMIT_FAILED 错误类型', () => {
+    expect(AuthHelperErrorType.FORM_SUBMIT_FAILED).toBeDefined();
+    expect(AuthHelperErrorType.FORM_SUBMIT_FAILED).toBe('FORM_SUBMIT_FAILED');
+  });
+
+  test('所有错误类型应该是字符串', () => {
+    const values = Object.values(AuthHelperErrorType);
+    values.forEach((value) => {
+      expect(typeof value).toBe('string');
+    });
+  });
+});
+
+// ============================================================================
+// AuthHelperError 类测试
+// ============================================================================
+
+test.describe('AuthHelperError', () => {
+  test('应该能够创建错误实例', () => {
+    const error = new AuthHelperError(
+      AuthHelperErrorType.NAVIGATION_FAILED,
+      'Navigation failed'
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(AuthHelperError);
+  });
+
+  test('应该正确设置错误名称', () => {
+    const error = new AuthHelperError(
+      AuthHelperErrorType.TIMEOUT,
+      'Operation timeout'
+    );
+
+    expect(error.name).toBe('AuthHelperError');
+  });
+
+  test('应该正确设置错误消息', () => {
+    const message = 'Element not found';
+    const error = new AuthHelperError(
+      AuthHelperErrorType.ELEMENT_NOT_FOUND,
+      message
+    );
+
+    expect(error.message).toBe(message);
+  });
+
+  test('应该正确设置错误类型', () => {
+    const error = new AuthHelperError(
+      AuthHelperErrorType.AUTH_STATE_MISMATCH,
+      'Auth state mismatch'
+    );
+
+    expect(error.type).toBe(AuthHelperErrorType.AUTH_STATE_MISMATCH);
+  });
+
+  test('应该支持可选的 context 参数', () => {
+    const context = { element: 'submit-button', timeout: 5000 };
+    const error = new AuthHelperError(
+      AuthHelperErrorType.ELEMENT_NOT_FOUND,
+      'Element not found',
+      context
+    );
+
+    expect(error.context).toEqual(context);
+  });
+
+  test('不提供 context 时应该为 undefined', () => {
+    const error = new AuthHelperError(
+      AuthHelperErrorType.FORM_SUBMIT_FAILED,
+      'Form submit failed'
+    );
+
+    expect(error.context).toBeUndefined();
+  });
+
+  test('应该能够作为 Error 被抛出和捕获', () => {
+    expect(() => {
+      throw new AuthHelperError(
+        AuthHelperErrorType.TIMEOUT,
+        'Timeout occurred'
+      );
+    }).toThrow(AuthHelperError);
+  });
+
+  test('应该能够使用 instanceof 检查错误类型', () => {
+    try {
+      throw new AuthHelperError(
+        AuthHelperErrorType.NAVIGATION_FAILED,
+        'Navigation failed'
+      );
+    } catch (e) {
+      expect(e).toBeInstanceOf(AuthHelperError);
+      expect(e).toBeInstanceOf(Error);
+    }
+  });
+
+  test('应该能够通过 type 属性区分错误类型', () => {
+    const navError = new AuthHelperError(
+      AuthHelperErrorType.NAVIGATION_FAILED,
+      'Nav failed'
+    );
+    const timeoutError = new AuthHelperError(
+      AuthHelperErrorType.TIMEOUT,
+      'Timeout'
+    );
+
+    expect(navError.type).not.toBe(timeoutError.type);
+  });
+
+  test('context 应该支持任意类型的数据', () => {
+    const context1 = { url: '/login', retryCount: 3 };
+    const context2 = { element: 'button', visible: false };
+    const context3 = { error: 'Network error', status: 500 };
+
+    const error1 = new AuthHelperError(
+      AuthHelperErrorType.NAVIGATION_FAILED,
+      'Failed',
+      context1
+    );
+    const error2 = new AuthHelperError(
+      AuthHelperErrorType.ELEMENT_NOT_FOUND,
+      'Not found',
+      context2
+    );
+    const error3 = new AuthHelperError(
+      AuthHelperErrorType.FORM_SUBMIT_FAILED,
+      'Submit failed',
+      context3
+    );
+
+    expect(error1.context).toEqual(context1);
+    expect(error2.context).toEqual(context2);
+    expect(error3.context).toEqual(context3);
+  });
+
+  test('错误堆栈应该正确设置', () => {
+    const error = new AuthHelperError(
+      AuthHelperErrorType.TIMEOUT,
+      'Timeout'
+    );
+
+    expect(error.stack).toBeDefined();
+    expect(typeof error.stack).toBe('string');
+  });
+});
+
+// ============================================================================
+// 错误使用场景测试
+// ============================================================================
+
+test.describe('错误使用场景', () => {
+  test('应该在页面导航失败时抛出 NAVIGATION_FAILED', async ({ page }) => {
+    // 模拟导航失败场景
+    const error = new AuthHelperError(
+      AuthHelperErrorType.NAVIGATION_FAILED,
+      'Failed to navigate to /login',
+      { url: '/login', timeout: 30000 }
+    );
+
+    expect(error.type).toBe(AuthHelperErrorType.NAVIGATION_FAILED);
+    expect(error.context?.url).toBe('/login');
+    expect(error.context?.timeout).toBe(30000);
+  });
+
+  test('应该在元素未找到时抛出 ELEMENT_NOT_FOUND', async ({ page }) => {
+    const error = new AuthHelperError(
+      AuthHelperErrorType.ELEMENT_NOT_FOUND,
+      'Submit button not found',
+      { selector: 'button[type="submit"]', timeout: 10000 }
+    );
+
+    expect(error.type).toBe(AuthHelperErrorType.ELEMENT_NOT_FOUND);
+    expect(error.context?.selector).toBe('button[type="submit"]');
+  });
+
+  test('应该在操作超时时抛出 TIMEOUT', async ({ page }) => {
+    const error = new AuthHelperError(
+      AuthHelperErrorType.TIMEOUT,
+      'Authentication state timeout',
+      { expectedState: 'authenticated', actualState: 'unauthenticated', timeout: 5000 }
+    );
+
+    expect(error.type).toBe(AuthHelperErrorType.TIMEOUT);
+    expect(error.context?.expectedState).toBe('authenticated');
+    expect(error.context?.timeout).toBe(5000);
+  });
+
+  test('应该在认证状态不匹配时抛出 AUTH_STATE_MISMATCH', async ({ page }) => {
+    const error = new AuthHelperError(
+      AuthHelperErrorType.AUTH_STATE_MISMATCH,
+      'Expected authenticated but got unauthenticated',
+      { expected: 'authenticated', actual: 'unauthenticated' }
+    );
+
+    expect(error.type).toBe(AuthHelperErrorType.AUTH_STATE_MISMATCH);
+    expect(error.context?.expected).toBe('authenticated');
+    expect(error.context?.actual).toBe('unauthenticated');
+  });
+
+  test('应该在表单提交失败时抛出 FORM_SUBMIT_FAILED', async ({ page }) => {
+    const error = new AuthHelperError(
+      AuthHelperErrorType.FORM_SUBMIT_FAILED,
+      'Form submission failed',
+      { form: 'login-form', error: 'Invalid credentials' }
+    );
+
+    expect(error.type).toBe(AuthHelperErrorType.FORM_SUBMIT_FAILED);
+    expect(error.context?.form).toBe('login-form');
+    expect(error.context?.error).toBe('Invalid credentials');
+  });
+});

--- a/frontend/e2e/helpers/__tests__/index.spec.ts
+++ b/frontend/e2e/helpers/__tests__/index.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * index.spec.ts
+ *
+ * helpers 模块导出测试
+ *
+ * 测试目标：验证统一导出文件是否正确导出所有内容
+ *
+ * 测试原则：
+ * - RED FIRST：这些测试在实现代码完成前运行应该是失败的
+ * - 简单性：直接验证导出内容
+ * - 独立性：每个测试用例独立运行
+ */
+
+import { test, expect } from '@playwright/test';
+
+// ============================================================================
+// 辅助函数导出测试
+// ============================================================================
+
+test.describe('helpers 导出 - 辅助函数', () => {
+  test('应该导出 registerUser 函数', async () => {
+    const { registerUser } = await import('../auth-helpers');
+    expect(registerUser).toBeDefined();
+    expect(typeof registerUser).toBe('function');
+  });
+
+  test('应该导出 loginUser 函数', async () => {
+    const { loginUser } = await import('../auth-helpers');
+    expect(loginUser).toBeDefined();
+    expect(typeof loginUser).toBe('function');
+  });
+
+  test('应该导出 logoutUser 函数', async () => {
+    const { logoutUser } = await import('../auth-helpers');
+    expect(logoutUser).toBeDefined();
+    expect(typeof logoutUser).toBe('function');
+  });
+
+  test('应该导出 clearAuth 函数', async () => {
+    const { clearAuth } = await import('../auth-helpers');
+    expect(clearAuth).toBeDefined();
+    expect(typeof clearAuth).toBe('function');
+  });
+
+  test('应该导出 waitForAuthState 函数', async () => {
+    const { waitForAuthState } = await import('../auth-helpers');
+    expect(waitForAuthState).toBeDefined();
+    expect(typeof waitForAuthState).toBe('function');
+  });
+
+  test('应该导出 getAuthState 函数', async () => {
+    const { getAuthState } = await import('../auth-helpers');
+    expect(getAuthState).toBeDefined();
+    expect(typeof getAuthState).toBe('function');
+  });
+});
+
+// ============================================================================
+// 类型导出测试
+// ============================================================================
+
+test.describe('helpers 导出 - 类型', () => {
+  test('应该导出 UserCredentials 类型', async () => {
+    const module = await import('../auth-helpers');
+    // TypeScript 类型在运行时不可用，这里验证模块可以正常导入
+    expect(module).toBeDefined();
+  });
+
+  test('应该导出 LoginCredentials 类型', async () => {
+    const module = await import('../auth-helpers');
+    expect(module).toBeDefined();
+  });
+
+  test('应该导出 RegisterUserOptions 类型', async () => {
+    const module = await import('../auth-helpers');
+    expect(module).toBeDefined();
+  });
+
+  test('应该导出 LoginUserOptions 类型', async () => {
+    const module = await import('../auth-helpers');
+    expect(module).toBeDefined();
+  });
+
+  test('应该导出 LogoutUserOptions 类型', async () => {
+    const module = await import('../auth-helpers');
+    expect(module).toBeDefined();
+  });
+
+  test('应该导出 WaitForAuthStateOptions 类型', async () => {
+    const module = await import('../auth-helpers');
+    expect(module).toBeDefined();
+  });
+
+  test('应该导出 ClearAuthOptions 类型', async () => {
+    const module = await import('../auth-helpers');
+    expect(module).toBeDefined();
+  });
+});
+
+// ============================================================================
+// 常量导出测试
+// ============================================================================
+
+test.describe('helpers 导出 - 常量', () => {
+  test('应该导出 AUTH_SELECTORS 常量', async () => {
+    const { AUTH_SELECTORS } = await import('../auth-helpers');
+    expect(AUTH_SELECTORS).toBeDefined();
+    expect(typeof AUTH_SELECTORS).toBe('object');
+  });
+
+  test('应该导出 STORAGE_KEYS 常量', async () => {
+    const { STORAGE_KEYS } = await import('../auth-helpers');
+    expect(STORAGE_KEYS).toBeDefined();
+    expect(typeof STORAGE_KEYS).toBe('object');
+  });
+
+  test('应该导出 DEFAULT_TIMEOUTS 常量', async () => {
+    const { DEFAULT_TIMEOUTS } = await import('../auth-helpers');
+    expect(DEFAULT_TIMEOUTS).toBeDefined();
+    expect(typeof DEFAULT_TIMEOUTS).toBe('object');
+  });
+});
+
+// ============================================================================
+// 错误类导出测试
+// ============================================================================
+
+test.describe('helpers 导出 - 错误类', () => {
+  test('应该导出 AuthHelperErrorType 枚举', async () => {
+    const { AuthHelperErrorType } = await import('../auth-helpers');
+    expect(AuthHelperErrorType).toBeDefined();
+    expect(typeof AuthHelperErrorType).toBe('object');
+  });
+
+  test('应该导出 AuthHelperError 类', async () => {
+    const { AuthHelperError } = await import('../auth-helpers');
+    expect(AuthHelperError).toBeDefined();
+    expect(typeof AuthHelperError).toBe('function');
+  });
+
+  test('AuthHelperError 应该可以实例化', async () => {
+    const { AuthHelperError, AuthHelperErrorType } = await import('../auth-helpers');
+    const error = new AuthHelperError(
+      AuthHelperErrorType.TIMEOUT,
+      'Test error'
+    );
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(AuthHelperError);
+  });
+});
+
+// ============================================================================
+// 导入路径测试
+// ============================================================================
+
+test.describe('导入路径', () => {
+  test('应该可以从相对路径导入', async () => {
+    const module = await import('../auth-helpers');
+    expect(module).toBeDefined();
+  });
+
+  test('应该可以导入所有导出内容', async () => {
+    const module = await import('../auth-helpers');
+    const exports = Object.keys(module);
+
+    // 验证关键导出存在
+    expect(exports).toContain('registerUser');
+    expect(exports).toContain('loginUser');
+    expect(exports).toContain('logoutUser');
+    expect(exports).toContain('clearAuth');
+    expect(exports).toContain('waitForAuthState');
+    expect(exports).toContain('getAuthState');
+    expect(exports).toContain('AUTH_SELECTORS');
+    expect(exports).toContain('STORAGE_KEYS');
+    expect(exports).toContain('DEFAULT_TIMEOUTS');
+    expect(exports).toContain('AuthHelperError');
+    expect(exports).toContain('AuthHelperErrorType');
+  });
+
+  test('每个导出应该是唯一的', async () => {
+    const module = await import('../auth-helpers');
+    const exports = Object.keys(module);
+    const uniqueExports = new Set(exports);
+
+    expect(exports.length).toBe(uniqueExports.size);
+  });
+});

--- a/frontend/e2e/helpers/auth-helpers.ts
+++ b/frontend/e2e/helpers/auth-helpers.ts
@@ -1,0 +1,516 @@
+/**
+ * E2E 测试认证辅助函数
+ *
+ * 职责：
+ * - 提供用户注册、登录、登出的辅助函数
+ * - 封装 Playwright Page API 操作
+ * - 提供认证状态等待和清除功能
+ *
+ * @depends
+ * - @playwright/test (Page, Locator)
+ * - @/types/auth (LoginRequest, RegisterRequest)
+ */
+
+import type { Page, Locator } from '@playwright/test';
+
+// ============================================================================
+// 常量定义
+// ============================================================================
+
+/**
+ * 认证相关选择器常量
+ */
+export const AUTH_SELECTORS = {
+  // 导航栏认证按钮
+  LOGIN_BUTTON: 'a[href="/login"]',
+  REGISTER_BUTTON: 'a[href="/register"]',
+  LOGOUT_BUTTON: 'button.header-auth-logout, button:has-text("登出"), button:has-text("退出"), [data-testid="logout-button"]',
+
+  // 表单输入
+  USERNAME_INPUT: 'input[name="username"], #username',
+  EMAIL_INPUT: 'input[name="email"], #email, input[type="email"]',
+  IDENTIFIER_INPUT: 'input[name="identifier"]',
+  PASSWORD_INPUT: 'input[name="password"], #password, input[type="password"]',
+
+  // 提交按钮
+  SUBMIT_BUTTON: 'button[type="submit"], .btn-primary',
+
+  // 认证状态指示器
+  USER_INFO: '.header-auth, [data-testid="user-info"], .user-info',
+  AUTH_INDICATOR: '[data-testid="auth-indicator"]',
+
+  // 错误消息
+  ERROR_MESSAGE: '.alert-error, .error-message, [data-testid="error"]',
+} as const;
+
+/**
+ * 存储键常量（需与前端代码保持一致）
+ */
+export const STORAGE_KEYS = {
+  TOKENS: 'auth_tokens',
+  AUTH_STATE: 'auth-state',
+} as const;
+
+/**
+ * 默认超时配置
+ */
+export const DEFAULT_TIMEOUTS = {
+  /** 页面导航超时 */
+  NAVIGATION: 30000,
+  /** 操作超时 */
+  ACTION: 10000,
+  /** 等待状态超时 */
+  WAIT_STATE: 5000,
+  /** 状态轮询间隔 */
+  POLL_INTERVAL: 200,
+} as const;
+
+// ============================================================================
+// 类型定义
+// ============================================================================
+
+/**
+ * 用户注册凭据
+ */
+export interface UserCredentials {
+  /** 用户名 */
+  username: string;
+  /** 邮箱地址 */
+  email: string;
+  /** 密码 */
+  password: string;
+}
+
+/**
+ * 登录凭据
+ */
+export interface LoginCredentials {
+  /** 用户名或邮箱 */
+  usernameOrEmail: string;
+  /** 密码 */
+  password: string;
+}
+
+/**
+ * 注册用户选项
+ */
+export interface RegisterUserOptions {
+  /** 注册后是否自动登录（默认 true） */
+  autoLogin?: boolean;
+  /** 注册后是否验证用户信息（默认 true） */
+  verifyUserInfo?: boolean;
+  /** 操作超时时间（毫秒，默认 10000） */
+  timeout?: number;
+}
+
+/**
+ * 登录用户选项
+ */
+export interface LoginUserOptions {
+  /** 登录后是否验证认证状态（默认 true） */
+  verifyAuth?: boolean;
+  /** 操作超时时间（毫秒，默认 10000） */
+  timeout?: number;
+}
+
+/**
+ * 登出用户选项
+ */
+export interface LogoutUserOptions {
+  /** 是否验证登出后的未认证状态（默认 true） */
+  verifyUnauth?: boolean;
+  /** 操作超时时间（毫秒，默认 10000） */
+  timeout?: number;
+}
+
+/**
+ * 等待认证状态选项
+ */
+export interface WaitForAuthStateOptions {
+  /** 目标认证状态 */
+  expectedStatus: 'authenticated' | 'unauthenticated';
+  /** 等待超时时间（毫秒，默认 5000） */
+  timeout?: number;
+  /** 轮询间隔（毫秒，默认 200） */
+  interval?: number;
+}
+
+/**
+ * 清除认证选项
+ */
+export interface ClearAuthOptions {
+  /** 是否清除 localStorage（默认 true） */
+  clearLocalStorage?: boolean;
+  /** 是否清除 cookies（默认 true） */
+  clearCookies?: boolean;
+  /** 是否清除 sessionStorage（默认 true） */
+  clearSessionStorage?: boolean;
+}
+
+/**
+ * 认证辅助函数错误类型
+ */
+export enum AuthHelperErrorType {
+  /** 页面导航失败 */
+  NAVIGATION_FAILED = 'NAVIGATION_FAILED',
+  /** 元素未找到 */
+  ELEMENT_NOT_FOUND = 'ELEMENT_NOT_FOUND',
+  /** 操作超时 */
+  TIMEOUT = 'TIMEOUT',
+  /** 认证状态验证失败 */
+  AUTH_STATE_MISMATCH = 'AUTH_STATE_MISMATCH',
+  /** 表单提交失败 */
+  FORM_SUBMIT_FAILED = 'FORM_SUBMIT_FAILED',
+}
+
+/**
+ * 认证辅助函数错误类
+ */
+export class AuthHelperError extends Error {
+  constructor(
+    public readonly type: AuthHelperErrorType,
+    message: string,
+    public readonly context?: Record<string, unknown>
+  ) {
+    super(message);
+    this.name = 'AuthHelperError';
+  }
+}
+
+// ============================================================================
+// 辅助函数实现
+// ============================================================================
+
+/**
+ * 注册新用户
+ *
+ * 逻辑流程：
+ * 1. 导航到注册页面 (/register)
+ * 2. 填写用户名、邮箱、密码
+ * 3. 提交注册表单
+ * 4. 可选：验证用户已登录
+ * 5. 返回用户凭据（供后续测试使用）
+ *
+ * @param page - Playwright Page 实例
+ * @param credentials - 用户注册凭据
+ * @param options - 注册选项
+ * @returns Promise<UserCredentials> 注册成功的用户凭据
+ *
+ * @example
+ * ```ts
+ * const credentials = await registerUser(page, {
+ *   username: 'testuser',
+ *   email: 'test@example.com',
+ *   password: 'TestPassword123!',
+ * }, { autoLogin: true });
+ * ```
+ */
+export async function registerUser(
+  page: Page,
+  credentials: UserCredentials,
+  options: RegisterUserOptions = {}
+): Promise<UserCredentials> {
+  const {
+    autoLogin = true,
+    verifyUserInfo = true,
+    timeout = DEFAULT_TIMEOUTS.ACTION,
+  } = options;
+
+  try {
+    // 1. 导航到注册页面
+    await page.goto('/register', { timeout: DEFAULT_TIMEOUTS.NAVIGATION });
+
+    // 2. 填写表单
+    const usernameInput = page.locator(AUTH_SELECTORS.USERNAME_INPUT).first();
+    const emailInput = page.locator(AUTH_SELECTORS.EMAIL_INPUT).first();
+    const passwordInput = page.locator(AUTH_SELECTORS.PASSWORD_INPUT).first();
+
+    await usernameInput.fill(credentials.username);
+    await emailInput.fill(credentials.email);
+    await passwordInput.fill(credentials.password);
+
+    // 3. 提交表单
+    const submitButton = page.locator(AUTH_SELECTORS.SUBMIT_BUTTON).first();
+    await submitButton.click();
+
+    // 4. 等待导航（注册成功后会跳转到首页）
+    if (autoLogin) {
+      await page.waitForURL('/', { timeout });
+    }
+
+    // 5. 验证用户信息显示（可选）
+    if (verifyUserInfo && autoLogin) {
+      const userInfo = page.locator(AUTH_SELECTORS.USER_INFO);
+      await userInfo.waitFor({ state: 'visible', timeout });
+    }
+
+    return credentials;
+  } catch (error) {
+    throw new AuthHelperError(
+      AuthHelperErrorType.FORM_SUBMIT_FAILED,
+      `注册用户失败: ${error instanceof Error ? error.message : String(error)}`,
+      { credentials }
+    );
+  }
+}
+
+/**
+ * 登录用户
+ *
+ * 逻辑流程：
+ * 1. 导航到登录页面 (/login)
+ * 2. 填写用户名/邮箱和密码
+ * 3. 提交登录表单
+ * 4. 可选：验证用户已认证
+ * 5. 返回登录凭据
+ *
+ * @param page - Playwright Page 实例
+ * @param credentials - 登录凭据
+ * @param options - 登录选项
+ * @returns Promise<LoginCredentials> 登录成功的凭据
+ *
+ * @example
+ * ```ts
+ * await loginUser(page, {
+ *   usernameOrEmail: 'testuser',
+ *   password: 'TestPassword123!',
+ * }, { verifyAuth: true });
+ * ```
+ */
+export async function loginUser(
+  page: Page,
+  credentials: LoginCredentials,
+  options: LoginUserOptions = {}
+): Promise<LoginCredentials> {
+  const {
+    verifyAuth = true,
+    timeout = DEFAULT_TIMEOUTS.ACTION,
+  } = options;
+
+  try {
+    // 1. 导航到登录页面
+    await page.goto('/login', { timeout: DEFAULT_TIMEOUTS.NAVIGATION });
+
+    // 2. 填写表单
+    // 登录表单使用 name="identifier" 的输入框
+    const identifierInput = page.locator(
+      AUTH_SELECTORS.IDENTIFIER_INPUT + ', ' + AUTH_SELECTORS.USERNAME_INPUT
+    ).first();
+    const passwordInput = page.locator(AUTH_SELECTORS.PASSWORD_INPUT).first();
+
+    await identifierInput.fill(credentials.usernameOrEmail);
+    await passwordInput.fill(credentials.password);
+
+    // 3. 提交表单
+    const submitButton = page.locator(AUTH_SELECTORS.SUBMIT_BUTTON).first();
+    await submitButton.click();
+
+    // 4. 等待导航（登录成功后会跳转到首页）
+    await page.waitForURL('/', { timeout });
+
+    // 5. 验证认证状态（可选）
+    if (verifyAuth) {
+      const userInfo = page.locator(AUTH_SELECTORS.USER_INFO);
+      await userInfo.waitFor({ state: 'visible', timeout });
+    }
+
+    return credentials;
+  } catch (error) {
+    throw new AuthHelperError(
+      AuthHelperErrorType.FORM_SUBMIT_FAILED,
+      `登录用户失败: ${error instanceof Error ? error.message : String(error)}`,
+      { credentials }
+    );
+  }
+}
+
+/**
+ * 登出用户
+ *
+ * 逻辑流程：
+ * 1. 查找并点击登出按钮
+ * 2. 可选：验证用户已登出
+ * 3. 清除本地认证状态
+ *
+ * @param page - Playwright Page 实例
+ * @param options - 登出选项
+ * @returns Promise<void>
+ *
+ * @example
+ * ```ts
+ * await logoutUser(page, { verifyUnauth: true });
+ * ```
+ */
+export async function logoutUser(
+  page: Page,
+  options: LogoutUserOptions = {}
+): Promise<void> {
+  const {
+    verifyUnauth = true,
+    timeout = DEFAULT_TIMEOUTS.ACTION,
+  } = options;
+
+  try {
+    // 1. 查找并点击登出按钮
+    const logoutButton = page.locator(AUTH_SELECTORS.LOGOUT_BUTTON).first();
+
+    // 等待登出按钮可见
+    await logoutButton.waitFor({ state: 'visible', timeout });
+    await logoutButton.click();
+
+    // 2. 验证已登出（可选）
+    if (verifyUnauth) {
+      // 验证登出后显示登录按钮
+      const loginButton = page.locator(AUTH_SELECTORS.LOGIN_BUTTON);
+      await loginButton.waitFor({ state: 'visible', timeout });
+    }
+  } catch (error) {
+    throw new AuthHelperError(
+      AuthHelperErrorType.ELEMENT_NOT_FOUND,
+      `登出用户失败: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+/**
+ * 清除认证状态（强制清理）
+ *
+ * 逻辑流程：
+ * 1. 清除 localStorage 中的 Token
+ * 2. 清除 cookies 中的认证信息
+ * 3. 清除 sessionStorage
+ * 4. 刷新页面以确保状态同步
+ *
+ * @param page - Playwright Page 实例
+ * @param options - 清除选项
+ * @returns Promise<void>
+ *
+ * @example
+ * ```ts
+ * await clearAuth(page, { clearLocalStorage: true });
+ * ```
+ */
+export async function clearAuth(
+  page: Page,
+  options: ClearAuthOptions = {}
+): Promise<void> {
+  const {
+    clearLocalStorage = true,
+    clearCookies = true,
+    clearSessionStorage = true,
+  } = options;
+
+  try {
+    // 清除 localStorage
+    if (clearLocalStorage) {
+      await page.evaluate(() => {
+        localStorage.removeItem('auth_tokens');
+        localStorage.removeItem('auth-state');
+      });
+    }
+
+    // 清除 sessionStorage
+    if (clearSessionStorage) {
+      await page.evaluate(() => {
+        sessionStorage.clear();
+      });
+    }
+
+    // 清除 cookies
+    if (clearCookies) {
+      const context = page.context();
+      await context.clearCookies();
+    }
+  } catch (error) {
+    throw new AuthHelperError(
+      AuthHelperErrorType.NAVIGATION_FAILED,
+      `清除认证状态失败: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+/**
+ * 等待认证状态变化
+ *
+ * 逻辑流程：
+ * 1. 轮询检查 localStorage 中的 Token 状态
+ * 2. 或检查页面上的认证状态指示器
+ * 3. 达到目标状态或超时后返回
+ *
+ * @param page - Playwright Page 实例
+ * @param options - 等待选项
+ * @returns Promise<boolean> 是否达到目标状态
+ *
+ * @example
+ * ```ts
+ * const isAuth = await waitForAuthState(page, {
+ *   expectedStatus: 'authenticated',
+ *   timeout: 5000,
+ * });
+ * ```
+ */
+export async function waitForAuthState(
+  page: Page,
+  options: WaitForAuthStateOptions
+): Promise<boolean> {
+  const {
+    expectedStatus,
+    timeout = DEFAULT_TIMEOUTS.WAIT_STATE,
+    interval = DEFAULT_TIMEOUTS.POLL_INTERVAL,
+  } = options;
+
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeout) {
+    const currentState = await getAuthState(page);
+
+    if (currentState === expectedStatus) {
+      return true;
+    }
+
+    // 等待指定间隔后重试
+    await page.waitForTimeout(interval);
+  }
+
+  // 超时返回 false
+  return false;
+}
+
+/**
+ * 获取当前认证状态（从 localStorage）
+ *
+ * 逻辑流程：
+ * 1. 读取 localStorage 中的 auth_tokens
+ * 2. 解析并验证 Token 是否过期
+ * 3. 返回认证状态
+ *
+ * @param page - Playwright Page 实例
+ * @returns Promise<'authenticated' | 'unauthenticated'> 当前认证状态
+ *
+ * @example
+ * ```ts
+ * const status = await getAuthState(page);
+ * ```
+ */
+export async function getAuthState(
+  page: Page
+): Promise<'authenticated' | 'unauthenticated'> {
+  try {
+    const hasTokens = await page.evaluate(() => {
+      const tokens = localStorage.getItem('auth_tokens');
+      if (!tokens) return false;
+
+      try {
+        const parsed = JSON.parse(tokens);
+        // 检查是否有 access_token
+        return !!parsed.access_token;
+      } catch {
+        return false;
+      }
+    });
+
+    return hasTokens ? 'authenticated' : 'unauthenticated';
+  } catch {
+    return 'unauthenticated';
+  }
+}

--- a/frontend/e2e/helpers/index.ts
+++ b/frontend/e2e/helpers/index.ts
@@ -1,0 +1,26 @@
+/**
+ * E2E 测试辅助函数统一导出
+ *
+ * @module e2e/helpers
+ */
+
+export {
+  registerUser,
+  loginUser,
+  logoutUser,
+  clearAuth,
+  waitForAuthState,
+  getAuthState,
+  AUTH_SELECTORS,
+  STORAGE_KEYS,
+  DEFAULT_TIMEOUTS,
+  type UserCredentials,
+  type LoginCredentials,
+  type RegisterUserOptions,
+  type LoginUserOptions,
+  type LogoutUserOptions,
+  type WaitForAuthStateOptions,
+  type ClearAuthOptions,
+  AuthHelperError,
+  AuthHelperErrorType,
+} from './auth-helpers';

--- a/frontend/e2e/pages/__tests__/auth-pages.spec.ts
+++ b/frontend/e2e/pages/__tests__/auth-pages.spec.ts
@@ -1,0 +1,258 @@
+/**
+ * auth-pages.spec.ts
+ *
+ * 认证页面对象模型 (POM) 单元测试
+ *
+ * 测试目标：验证 auth-pages.ts 中的页面对象行为
+ *
+ * 测试原则：
+ * - RED FIRST：这些测试在实现代码完成前运行应该是失败的
+ * - 简单性：测试代码逻辑简单，断言清晰
+ * - 独立性：每个测试用例独立运行
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  createRegisterPage,
+  createLoginPage,
+  RegisterPage,
+  LoginPage,
+} from '../auth-pages';
+
+// ============================================================================
+// 测试数据常量
+// ============================================================================
+
+const TEST_CREDENTIALS = {
+  username: 'testuser',
+  email: 'test@example.com',
+  password: 'TestPassword123!',
+};
+
+// ============================================================================
+// RegisterPage 测试
+// ============================================================================
+
+test.describe('RegisterPage', () => {
+  test('应该有正确的 URL 常量', async ({ page }) => {
+    expect(RegisterPage.URL).toBe('/register');
+  });
+
+  test('应该能够导航到注册页面', async ({ page }) => {
+    const registerPage = createRegisterPage(page);
+    await registerPage.goto();
+
+    expect(page.url()).toContain('/register');
+  });
+
+  test('应该能够定位所有页面元素', async ({ page }) => {
+    const registerPage = createRegisterPage(page);
+    await registerPage.goto();
+
+    // 验证元素存在
+    await expect(registerPage.usernameInput).toBeAttached();
+    await expect(registerPage.emailInput).toBeAttached();
+    await expect(registerPage.passwordInput).toBeAttached();
+    await expect(registerPage.submitButton).toBeAttached();
+    await expect(registerPage.loginLink).toBeAttached();
+  });
+
+  test('应该能够填写并提交注册表单', async ({ page }) => {
+    const registerPage = createRegisterPage(page);
+    await registerPage.goto();
+
+    await registerPage.register(
+      TEST_CREDENTIALS.username,
+      TEST_CREDENTIALS.email,
+      TEST_CREDENTIALS.password
+    );
+
+    // 验证表单提交后页面跳转
+    expect(page.url()).not.toContain('/register');
+  });
+
+  test('register 方法应该按顺序填写字段', async ({ page }) => {
+    const registerPage = createRegisterPage(page);
+    await registerPage.goto();
+
+    await registerPage.usernameInput.fill(TEST_CREDENTIALS.username);
+    const usernameValue = await registerPage.usernameInput.inputValue();
+    expect(usernameValue).toBe(TEST_CREDENTIALS.username);
+
+    await registerPage.emailInput.fill(TEST_CREDENTIALS.email);
+    const emailValue = await registerPage.emailInput.inputValue();
+    expect(emailValue).toBe(TEST_CREDENTIALS.email);
+
+    await registerPage.passwordInput.fill(TEST_CREDENTIALS.password);
+    const passwordValue = await registerPage.passwordInput.inputValue();
+    expect(passwordValue).toBe(TEST_CREDENTIALS.password);
+  });
+
+  test('应该能够跳转到登录页面', async ({ page }) => {
+    const registerPage = createRegisterPage(page);
+    await registerPage.goto();
+
+    await registerPage.goToLogin();
+
+    expect(page.url()).toContain('/login');
+  });
+});
+
+// ============================================================================
+// LoginPage 测试
+// ============================================================================
+
+test.describe('LoginPage', () => {
+  test('应该有正确的 URL 常量', async ({ page }) => {
+    expect(LoginPage.URL).toBe('/login');
+  });
+
+  test('应该能够导航到登录页面', async ({ page }) => {
+    const loginPage = createLoginPage(page);
+    await loginPage.goto();
+
+    expect(page.url()).toContain('/login');
+  });
+
+  test('应该能够定位所有页面元素', async ({ page }) => {
+    const loginPage = createLoginPage(page);
+    await loginPage.goto();
+
+    // 验证元素存在
+    await expect(loginPage.usernameOrEmailInput).toBeAttached();
+    await expect(loginPage.passwordInput).toBeAttached();
+    await expect(loginPage.submitButton).toBeAttached();
+    await expect(loginPage.registerLink).toBeAttached();
+  });
+
+  test('应该能够填写并提交登录表单', async ({ page }) => {
+    const loginPage = createLoginPage(page);
+    await loginPage.goto();
+
+    await loginPage.login(
+      TEST_CREDENTIALS.username,
+      TEST_CREDENTIALS.password
+    );
+
+    // 验证表单提交后页面跳转
+    expect(page.url()).not.toContain('/login');
+  });
+
+  test('login 方法应该正确填写用户名和密码', async ({ page }) => {
+    const loginPage = createLoginPage(page);
+    await loginPage.goto();
+
+    await loginPage.usernameOrEmailInput.fill(TEST_CREDENTIALS.username);
+    const usernameValue = await loginPage.usernameOrEmailInput.inputValue();
+    expect(usernameValue).toBe(TEST_CREDENTIALS.username);
+
+    await loginPage.passwordInput.fill(TEST_CREDENTIALS.password);
+    const passwordValue = await loginPage.passwordInput.inputValue();
+    expect(passwordValue).toBe(TEST_CREDENTIALS.password);
+  });
+
+  test('应该支持使用邮箱登录', async ({ page }) => {
+    const loginPage = createLoginPage(page);
+    await loginPage.goto();
+
+    await loginPage.usernameOrEmailInput.fill(TEST_CREDENTIALS.email);
+    const emailValue = await loginPage.usernameOrEmailInput.inputValue();
+    expect(emailValue).toBe(TEST_CREDENTIALS.email);
+  });
+
+  test('应该能够跳转到注册页面', async ({ page }) => {
+    const loginPage = createLoginPage(page);
+    await loginPage.goto();
+
+    await loginPage.goToRegister();
+
+    expect(page.url()).toContain('/register');
+  });
+});
+
+// ============================================================================
+// 工厂函数测试
+// ============================================================================
+
+test.describe('工厂函数', () => {
+  test('createRegisterPage 应该返回 RegisterPage 实例', async ({ page }) => {
+    const registerPage = createRegisterPage(page);
+
+    expect(registerPage).toBeInstanceOf(RegisterPage);
+    expect(registerPage.page).toBe(page);
+  });
+
+  test('createLoginPage 应该返回 LoginPage 实例', async ({ page }) => {
+    const loginPage = createLoginPage(page);
+
+    expect(loginPage).toBeInstanceOf(LoginPage);
+    expect(loginPage.page).toBe(page);
+  });
+});
+
+// ============================================================================
+// 页面交互完整流程测试
+// ============================================================================
+
+test.describe('页面交互完整流程', () => {
+  test('从注册页面跳转到登录页面', async ({ page }) => {
+    const registerPage = createRegisterPage(page);
+    await registerPage.goto();
+
+    // 验证在注册页面
+    expect(page.url()).toContain('/register');
+
+    // 跳转到登录
+    await registerPage.goToLogin();
+
+    // 验证在登录页面
+    expect(page.url()).toContain('/login');
+
+    const loginPage = createLoginPage(page);
+    await expect(loginPage.usernameOrEmailInput).toBeAttached();
+  });
+
+  test('从登录页面跳转到注册页面', async ({ page }) => {
+    const loginPage = createLoginPage(page);
+    await loginPage.goto();
+
+    // 验证在登录页面
+    expect(page.url()).toContain('/login');
+
+    // 跳转到注册
+    await loginPage.goToRegister();
+
+    // 验证在注册页面
+    expect(page.url()).toContain('/register');
+
+    const registerPage = createRegisterPage(page);
+    await expect(registerPage.usernameInput).toBeAttached();
+  });
+
+  test('使用 POM 完成注册流程', async ({ page }) => {
+    const registerPage = createRegisterPage(page);
+    await registerPage.goto();
+
+    await registerPage.register(
+      TEST_CREDENTIALS.username,
+      TEST_CREDENTIALS.email,
+      TEST_CREDENTIALS.password
+    );
+
+    // 验证注册成功
+    expect(page.url()).not.toContain('/register');
+  });
+
+  test('使用 POM 完成登录流程', async ({ page }) => {
+    const loginPage = createLoginPage(page);
+    await loginPage.goto();
+
+    await loginPage.login(
+      TEST_CREDENTIALS.username,
+      TEST_CREDENTIALS.password
+    );
+
+    // 验证登录成功
+    expect(page.url()).not.toContain('/login');
+  });
+});

--- a/frontend/e2e/pages/auth-pages.ts
+++ b/frontend/e2e/pages/auth-pages.ts
@@ -1,0 +1,210 @@
+/**
+ * 认证相关页面对象模型 (Page Object Model)
+ *
+ * 职责：
+ * - 封装认证相关页面的选择器和操作
+ * - 提供类型安全的页面元素访问
+ *
+ * @depends
+ * - @playwright/test (Page, Locator)
+ */
+
+import type { Page, Locator } from '@playwright/test';
+
+// ============================================================================
+// 注册页面
+// ============================================================================
+
+/**
+ * 注册页面类
+ */
+export class RegisterPage {
+  readonly page: Page;
+
+  // 页面 URL
+  static readonly URL = '/register';
+
+  // 页面元素选择器
+  readonly usernameInput: Locator;
+  readonly emailInput: Locator;
+  readonly passwordInput: Locator;
+  readonly confirmPasswordInput: Locator;
+  readonly submitButton: Locator;
+  readonly loginLink: Locator;
+  readonly errorMessage: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.usernameInput = page.locator('input[name="username"], #username');
+    this.emailInput = page.locator('input[name="email"], #email, input[type="email"]');
+    this.passwordInput = page.locator('input[name="password"]:first-of-type, #password, input[type="password"]:first-of-type');
+    this.confirmPasswordInput = page.locator('input[name="confirmPassword"], input[name="confirm_password"]');
+    this.submitButton = page.locator('button[type="submit"], .btn-primary');
+    this.loginLink = page.locator('a[href="/login"], .login-link');
+    this.errorMessage = page.locator('.alert-error, .error-message, [data-testid="error"]');
+  }
+
+  /**
+   * 导航到注册页面
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(RegisterPage.URL);
+  }
+
+  /**
+   * 填写并提交注册表单
+   *
+   * @param username - 用户名
+   * @param email - 邮箱
+   * @param password - 密码
+   * @param confirmPassword - 确认密码（可选）
+   */
+  async register(
+    username: string,
+    email: string,
+    password: string,
+    confirmPassword?: string
+  ): Promise<void> {
+    await this.usernameInput.fill(username);
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+
+    // 如果存在确认密码字段，则填写
+    if (confirmPassword !== undefined) {
+      await this.confirmPasswordInput.fill(confirmPassword);
+    }
+
+    await this.submitButton.click();
+  }
+
+  /**
+   * 跳转到登录页面
+   */
+  async goToLogin(): Promise<void> {
+    await this.loginLink.click();
+  }
+
+  /**
+   * 获取错误消息
+   */
+  async getErrorMessage(): Promise<string | null> {
+    const isVisible = await this.errorMessage.isVisible().catch(() => false);
+    if (!isVisible) return null;
+    return this.errorMessage.textContent();
+  }
+
+  /**
+   * 检查是否显示错误
+   */
+  async hasError(): Promise<boolean> {
+    return this.errorMessage.isVisible().catch(() => false);
+  }
+}
+
+// ============================================================================
+// 登录页面
+// ============================================================================
+
+/**
+ * 登录页面类
+ */
+export class LoginPage {
+  readonly page: Page;
+
+  // 页面 URL
+  static readonly URL = '/login';
+
+  // 页面元素选择器
+  readonly identifierInput: Locator;
+  readonly usernameOrEmailInput: Locator; // 别名，用于测试
+  readonly passwordInput: Locator;
+  readonly submitButton: Locator;
+  readonly registerLink: Locator;
+  readonly errorMessage: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.identifierInput = page.locator(
+      'input[name="identifier"], input[name="username"], input[name="email"], #username, #email'
+    );
+    this.usernameOrEmailInput = this.identifierInput; // 别名
+    this.passwordInput = page.locator('input[name="password"], #password, input[type="password"]');
+    this.submitButton = page.locator('button[type="submit"], .btn-primary');
+    this.registerLink = page.locator('a[href="/register"], .register-link');
+    this.errorMessage = page.locator('.alert-error, .error-message, [data-testid="error"]');
+  }
+
+  /**
+   * 导航到登录页面
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(LoginPage.URL);
+  }
+
+  /**
+   * 填写并提交登录表单
+   *
+   * @param usernameOrEmail - 用户名或邮箱
+   * @param password - 密码
+   */
+  async login(usernameOrEmail: string, password: string): Promise<void> {
+    await this.identifierInput.fill(usernameOrEmail);
+    await this.passwordInput.fill(password);
+    await this.submitButton.click();
+  }
+
+  /**
+   * 跳转到注册页面
+   */
+  async goToRegister(): Promise<void> {
+    await this.registerLink.click();
+  }
+
+  /**
+   * 获取错误消息
+   */
+  async getErrorMessage(): Promise<string | null> {
+    const isVisible = await this.errorMessage.isVisible().catch(() => false);
+    if (!isVisible) return null;
+    return this.errorMessage.textContent();
+  }
+
+  /**
+   * 检查是否显示错误
+   */
+  async hasError(): Promise<boolean> {
+    return this.errorMessage.isVisible().catch(() => false);
+  }
+}
+
+// ============================================================================
+// 导出工厂函数
+// ============================================================================
+
+/**
+ * 创建认证页面对象
+ *
+ * @example
+ * ```ts
+ * const registerPage = createRegisterPage(page);
+ * await registerPage.goto();
+ * await registerPage.register('user', 'user@example.com', 'pass');
+ * ```
+ */
+export function createRegisterPage(page: Page): RegisterPage {
+  return new RegisterPage(page);
+}
+
+/**
+ * 创建登录页面对象
+ *
+ * @example
+ * ```ts
+ * const loginPage = createLoginPage(page);
+ * await loginPage.goto();
+ * await loginPage.login('user', 'pass');
+ * ```
+ */
+export function createLoginPage(page: Page): LoginPage {
+  return new LoginPage(page);
+}


### PR DESCRIPTION
## 摘要

- 实现 auth-helpers.ts，提供 registerUser/loginUser/logoutUser 等辅助函数
- 添加 auth-pages.ts 页面对象模型
- 包含完整的类型定义和错误处理机制
- 添加单元测试覆盖所有辅助函数

## 测试计划

- [ ] 所有新增单元测试通过
- [ ] 可在 E2E 测试中正常导入和使用辅助函数
- [ ] 代码符合项目规范

Relates to #158

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)