### PR TITLE
test: 编写认证流程完整 E2E 测试套件 (Issue #138)

### DIFF
--- a/frontend/e2e/fixtures/auth/test-data.ts
+++ b/frontend/e2e/fixtures/auth/test-data.ts
@@ -1,0 +1,225 @@
+/**
+ * 认证测试数据 Fixtures
+ *
+ * 职责：
+ * - 提供测试用的用户数据
+ * - 提供无效数据用于验证测试
+ * - 生成唯一标识符避免测试冲突
+ *
+ * @module e2e/fixtures/auth/test-data
+ */
+
+// ============================================================================
+// 类型定义
+// ============================================================================
+
+/**
+ * 用户凭据
+ */
+export interface UserCredentials {
+  /** 用户名 */
+  username: string;
+  /** 邮箱地址 */
+  email: string;
+  /** 密码 */
+  password: string;
+}
+
+/**
+ * 登录凭据
+ */
+export interface LoginCredentials {
+  /** 用户名或邮箱 */
+  usernameOrEmail: string;
+  /** 密码 */
+  password: string;
+}
+
+// ============================================================================
+// 辅助函数
+// ============================================================================
+
+/**
+ * 生成唯一标识符（基于时间戳和随机数）
+ * @returns 唯一字符串
+ */
+export function generateUniqueId(): string {
+  return `${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+}
+
+/**
+ * 生成唯一的测试用户名
+ * @param prefix 前缀（默认 'testuser'）
+ * @returns 唯一用户名
+ */
+export function generateUsername(prefix: string = 'testuser'): string {
+  return `${prefix}_${generateUniqueId()}`;
+}
+
+/**
+ * 生成唯一的测试邮箱
+ * @param prefix 前缀（默认 'testuser'）
+ * @returns 唯一邮箱地址
+ */
+export function generateEmail(prefix: string = 'testuser'): string {
+  const uniqueId = generateUniqueId();
+  return `${prefix}_${uniqueId}@example.com`;
+}
+
+/**
+ * 生成固定的测试用户（用于跨测试共享）
+ * @param identifier 标识符
+ * @returns 用户凭据
+ */
+export function createFixedUser(identifier: string): UserCredentials {
+  return {
+    username: `testuser_${identifier}`,
+    email: `testuser_${identifier}@example.com`,
+    password: 'TestPass123!',
+  };
+}
+
+// ============================================================================
+// 有效测试数据
+// ============================================================================
+
+/**
+ * 有效的用户凭据（符合所有验证规则）
+ */
+export const VALID_USER: UserCredentials = {
+  username: 'testuser',
+  email: 'testuser@example.com',
+  password: 'TestPass123!',
+};
+
+/**
+ * 有效的登录凭据（用户名）
+ */
+export const VALID_LOGIN_BY_USERNAME: LoginCredentials = {
+  usernameOrEmail: 'testuser',
+  password: 'TestPass123!',
+};
+
+/**
+ * 有效的登录凭据（邮箱）
+ */
+export const VALID_LOGIN_BY_EMAIL: LoginCredentials = {
+  usernameOrEmail: 'testuser@example.com',
+  password: 'TestPass123!',
+};
+
+/**
+ * 边界值有效数据（最小长度）
+ */
+export const VALID_MINIMAL: UserCredentials = {
+  username: 'abc',           // 最少 3 字符
+  email: 'a@b.co',           // 有效邮箱
+  password: '12345678',      // 最少 8 字符
+};
+
+/**
+ * 边界值有效数据（最大长度）
+ */
+export const VALID_MAXIMUM: UserCredentials = {
+  username: 'a'.repeat(50),              // 最多 50 字符
+  email: 'verylongemailaddress@verylongdomain.com',
+  password: 'a'.repeat(100),             // 最多 100 字符
+};
+
+// ============================================================================
+// 无效测试数据（用于表单验证）
+// ============================================================================
+
+/**
+ * 用户名过短（少于 3 字符）
+ */
+export const INVALID_SHORT_USERNAME: UserCredentials = {
+  username: 'ab',
+  email: 'test@example.com',
+  password: 'TestPass123!',
+};
+
+/**
+ * 用户名过长（超过 50 字符）
+ */
+export const INVALID_LONG_USERNAME: UserCredentials = {
+  username: 'a'.repeat(51),
+  email: 'test@example.com',
+  password: 'TestPass123!',
+};
+
+/**
+ * 无效邮箱格式
+ */
+export const INVALID_EMAIL_FORMAT: UserCredentials = {
+  username: 'testuser',
+  email: 'invalid-email',
+  password: 'TestPass123!',
+};
+
+/**
+ * 密码过短（少于 8 字符）
+ */
+export const INVALID_SHORT_PASSWORD: UserCredentials = {
+  username: 'testuser',
+  email: 'testuser@example.com',
+  password: 'abc123',
+};
+
+/**
+ * 密码过长（超过 100 字符）
+ */
+export const INVALID_LONG_PASSWORD: UserCredentials = {
+  username: 'testuser',
+  email: 'testuser@example.com',
+  password: 'a'.repeat(101),
+};
+
+/**
+ * 空字段数据
+ */
+export const INVALID_EMPTY_FIELDS = {
+  username: '',
+  email: '',
+  password: '',
+};
+
+// ============================================================================
+// 错误场景测试数据
+// ============================================================================
+
+/**
+ * 用于测试重复用户名的数据
+ * （在注册测试中，先用 VALID_USER 注册，再用此数据测试）
+ */
+export const DUPLICATE_USERNAME: UserCredentials = {
+  username: 'testuser',     // 与 VALID_USER 相同
+  email: 'another@example.com',
+  password: 'TestPass123!',
+};
+
+/**
+ * 用于测试重复邮箱的数据
+ * （在注册测试中，先用 VALID_USER 注册，再用此数据测试）
+ */
+export const DUPLICATE_EMAIL: UserCredentials = {
+  username: 'anotheruser',
+  email: 'testuser@example.com',  // 与 VALID_USER 相同
+  password: 'TestPass123!',
+};
+
+/**
+ * 错误的登录凭据（密码错误）
+ */
+export const INVALID_PASSWORD: LoginCredentials = {
+  usernameOrEmail: 'testuser',
+  password: 'WrongPassword123!',
+};
+
+/**
+ * 不存在的用户凭据
+ */
+export const NON_EXISTENT_USER: LoginCredentials = {
+  usernameOrEmail: 'nonexistentuser',
+  password: 'TestPass123!',
+};

--- a/frontend/e2e/specs/auth/login.spec.ts
+++ b/frontend/e2e/specs/auth/login.spec.ts
@@ -1,0 +1,324 @@
+/**
+ * 登录流程 E2E 测试
+ *
+ * 测试范围：
+ * 1. 用户名登录
+ * 2. 邮箱登录
+ * 3. 错误处理（错误密码、不存在用户、空字段）
+ *
+ * @see /workspace/frontend/e2e/helpers/auth-helpers.ts
+ * @see /workspace/frontend/e2e/pages/auth-pages.ts
+ */
+
+import { test, expect } from '@playwright/test';
+import { LoginPage } from '../../pages/auth-pages';
+import { registerUser, loginUser, clearAuth } from '../../helpers/auth-helpers';
+import {
+  VALID_USER,
+  INVALID_PASSWORD,
+  NON_EXISTENT_USER,
+  generateUsername,
+  generateEmail,
+} from '../../fixtures/auth/test-data';
+
+// ============================================================================
+// 登录流程测试套件
+// ============================================================================
+
+test.describe('登录流程', () => {
+  // 每个测试前清除认证状态
+  test.beforeEach(async ({ page }) => {
+    await clearAuth(page);
+  });
+
+  // ==========================================================================
+  // 用户名登录测试
+  // ==========================================================================
+
+  test.describe('用户名登录', () => {
+    test('应支持用户名登录', async ({ page }) => {
+      // 首先注册一个用户
+      const testUser = {
+        username: generateUsername('login_test'),
+        email: generateEmail('login_test'),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, testUser, { autoLogin: true });
+
+      // 清除认证状态，准备测试登录
+      await clearAuth(page);
+
+      // 使用用户名登录
+      await loginUser(page, {
+        usernameOrEmail: testUser.username,
+        password: testUser.password,
+      });
+
+      // 验证已跳转到首页
+      await expect(page).toHaveURL('/');
+
+      // 验证用户信息显示
+      const userInfo = page.locator('[data-testid="user-info"], .user-info, .header-auth');
+      await expect(userInfo).toBeVisible();
+    });
+
+    test('用户名登录应区分大小写', async ({ page }) => {
+      // 注册用户（小写）
+      const testUser = {
+        username: generateUsername('case_test').toLowerCase(),
+        email: generateEmail('case_test'),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, testUser, { autoLogin: true });
+      await clearAuth(page);
+
+      // 使用大写用户名登录（应该失败）
+      const loginPage = new LoginPage(page);
+      await loginPage.goto();
+      await loginPage.login(
+        testUser.username.toUpperCase(),
+        testUser.password
+      );
+
+      // 验证显示错误或仍在登录页面
+      const hasError = await loginPage.hasError();
+      const currentUrl = page.url();
+
+      expect(
+        hasError || currentUrl.includes('/login'),
+        '应显示错误或停留在登录页面'
+      ).toBeTruthy();
+    });
+  });
+
+  // ==========================================================================
+  // 邮箱登录测试
+  // ==========================================================================
+
+  test.describe('邮箱登录', () => {
+    test('应支持邮箱登录', async ({ page }) => {
+      // 首先注册一个用户
+      const testUser = {
+        username: generateUsername('email_login'),
+        email: generateEmail('email_login'),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, testUser, { autoLogin: true });
+
+      // 清除认证状态，准备测试登录
+      await clearAuth(page);
+
+      // 使用邮箱登录
+      await loginUser(page, {
+        usernameOrEmail: testUser.email,
+        password: testUser.password,
+      });
+
+      // 验证已跳转到首页
+      await expect(page).toHaveURL('/');
+
+      // 验证用户信息显示
+      const userInfo = page.locator('[data-testid="user-info"], .user-info, .header-auth');
+      await expect(userInfo).toBeVisible();
+    });
+
+    test('邮箱登录应不区分大小写', async ({ page }) => {
+      // 注册用户
+      const testUser = {
+        username: generateUsername('email_case'),
+        email: `test_${Date.now()}@EXAMPLE.COM`,
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, testUser, { autoLogin: true });
+      await clearAuth(page);
+
+      // 使用小写邮箱登录（应该成功）
+      await loginUser(page, {
+        usernameOrEmail: testUser.email.toLowerCase(),
+        password: testUser.password,
+      });
+
+      // 验证登录成功
+      await expect(page).toHaveURL('/');
+    });
+  });
+
+  // ==========================================================================
+  // 错误处理测试
+  // ==========================================================================
+
+  test.describe('错误处理', () => {
+    test('应显示用户名或密码错误提示', async ({ page }) => {
+      // 首先注册一个用户
+      const testUser = {
+        username: generateUsername('wrong_pass'),
+        email: generateEmail('wrong_pass'),
+        password: 'CorrectPass123!',
+      };
+
+      await registerUser(page, testUser, { autoLogin: true });
+      await clearAuth(page);
+
+      // 使用错误密码登录
+      const loginPage = new LoginPage(page);
+      await loginPage.goto();
+      await loginPage.login(
+        testUser.username,
+        'WrongPassword123!'
+      );
+
+      // 验证显示错误或仍在登录页面
+      const hasError = await loginPage.hasError();
+      const currentUrl = page.url();
+
+      expect(
+        hasError || currentUrl.includes('/login'),
+        '应显示错误或停留在登录页面'
+      ).toBeTruthy();
+
+      // 验证没有跳转到首页（登录失败）
+      await expect(page).not.toHaveURL('/');
+    });
+
+    test('应显示用户不存在错误', async ({ page }) => {
+      const loginPage = new LoginPage(page);
+      await loginPage.goto();
+
+      // 尝试登录不存在的用户
+      await loginPage.login(
+        'nonexistentuser_' + Date.now(),
+        'SomePassword123!'
+      );
+
+      // 验证显示错误或仍在登录页面
+      const hasError = await loginPage.hasError();
+      const currentUrl = page.url();
+
+      expect(
+        hasError || currentUrl.includes('/login'),
+        '应显示错误或停留在登录页面'
+      ).toBeTruthy();
+
+      // 验证没有跳转到首页（登录失败）
+      await expect(page).not.toHaveURL('/');
+    });
+
+    test('应验证空用户名字段', async ({ page }) => {
+      const loginPage = new LoginPage(page);
+      await loginPage.goto();
+
+      // 尝试使用空用户名登录
+      await loginPage.login('', 'SomePassword123!');
+
+      // 验证没有提交（表单验证或仍在登录页面）
+      const currentUrl = page.url();
+      expect(currentUrl).toContain('/login');
+    });
+
+    test('应验证空密码字段', async ({ page }) => {
+      const loginPage = new LoginPage(page);
+      await loginPage.goto();
+
+      // 尝试使用空密码登录
+      await loginPage.login('testuser', '');
+
+      // 验证没有提交（表单验证或仍在登录页面）
+      const currentUrl = page.url();
+      expect(currentUrl).toContain('/login');
+    });
+
+    test('应验证所有字段为空', async ({ page }) => {
+      const loginPage = new LoginPage(page);
+      await loginPage.goto();
+
+      // 尝试使用空字段登录
+      await loginPage.login('', '');
+
+      // 验证没有提交（表单验证或仍在登录页面）
+      const currentUrl = page.url();
+      expect(currentUrl).toContain('/login');
+    });
+  });
+
+  // ==========================================================================
+  // 登录后状态验证测试
+  // ==========================================================================
+
+  test.describe('登录后状态', () => {
+    test('登录成功后应显示用户名', async ({ page }) => {
+      const testUser = {
+        username: generateUsername('display_name'),
+        email: generateEmail('display_name'),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, testUser, { autoLogin: true });
+      await clearAuth(page);
+
+      // 登录
+      await loginUser(page, {
+        usernameOrEmail: testUser.username,
+        password: testUser.password,
+      });
+
+      // 验证用户名显示在页面上
+      const pageContent = await page.content();
+      expect(pageContent).toContain(testUser.username);
+    });
+
+    test('登录成功后应存储 Token 到 localStorage', async ({ page }) => {
+      const testUser = {
+        username: generateUsername('token_test'),
+        email: generateEmail('token_test'),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, testUser, { autoLogin: true });
+      await clearAuth(page);
+
+      // 登录
+      await loginUser(page, {
+        usernameOrEmail: testUser.username,
+        password: testUser.password,
+      });
+
+      // 验证 Token 已存储到 localStorage
+      const hasTokens = await page.evaluate(() => {
+        const tokens = localStorage.getItem('auth_tokens');
+        return !!tokens;
+      });
+
+      expect(hasTokens).toBeTruthy();
+    });
+  });
+
+  // ==========================================================================
+  // UI 交互测试
+  // ==========================================================================
+
+  test.describe('UI 交互', () => {
+    test('应能从登录页面跳转到注册页面', async ({ page }) => {
+      const loginPage = new LoginPage(page);
+      await loginPage.goto();
+      await loginPage.goToRegister();
+
+      // 验证已跳转到注册页面
+      await expect(page).toHaveURL(/\/register/);
+    });
+
+    test('登录页面应包含必要的表单元素', async ({ page }) => {
+      const loginPage = new LoginPage(page);
+      await loginPage.goto();
+
+      // 验证所有表单元素存在
+      await expect(loginPage.identifierInput).toBeVisible();
+      await expect(loginPage.passwordInput).toBeVisible();
+      await expect(loginPage.submitButton).toBeVisible();
+      await expect(loginPage.registerLink).toBeVisible();
+    });
+  });
+});

--- a/frontend/e2e/specs/auth/logout.spec.ts
+++ b/frontend/e2e/specs/auth/logout.spec.ts
@@ -1,0 +1,289 @@
+/**
+ * 登出流程 E2E 测试
+ *
+ * 验收标准覆盖：
+ * AC1: 用户可以主动登出
+ * AC2: 登出后应清除所有认证状态
+ * AC3: 登出后应重定向到首页并显示登录按钮
+ *
+ * @module e2e/specs/auth/logout
+ */
+
+import { test, expect } from '@playwright/test';
+import { RegisterPage } from '../../pages/auth-pages';
+import { registerUser, logoutUser, clearAuth, getAuthState, STORAGE_KEYS } from '../../helpers/auth-helpers';
+import { generateUsername, generateEmail } from '../../fixtures/auth/test-data';
+
+test.describe('登出流程', () => {
+  // ========================================================================
+  // 基础登出测试
+  // ========================================================================
+
+  test.describe('基础登出', () => {
+    test('点击登出按钮应清除认证状态', async ({ page }) => {
+      // Arrange - 注册并登录
+      const testUser = {
+        username: generateUsername(),
+        email: generateEmail(),
+        password: 'TestPass123!',
+      };
+      await registerUser(page, testUser);
+
+      // 验证已登录
+      await expect(page).toHaveURL('/');
+      const userInfoBefore = page.locator('[data-testid="user-info"], .header-auth, .user-info');
+      await expect(userInfoBefore).toBeVisible();
+
+      // Act - 点击登出按钮
+      await logoutUser(page);
+
+      // Assert - 用户信息应不可见
+      const userInfoAfter = page.locator('[data-testid="user-info"], .header-auth, .user-info');
+      await expect(userInfoAfter).not.toBeVisible();
+    });
+
+    test('登出后应显示登录按钮', async ({ page }) => {
+      // Arrange - 注册并登录
+      const testUser = {
+        username: generateUsername(),
+        email: generateEmail(),
+        password: 'TestPass123!',
+      };
+      await registerUser(page, testUser);
+
+      // Act - 点击登出按钮
+      await logoutUser(page);
+
+      // Assert - 应显示登录按钮
+      const loginButton = page.locator('a[href="/login"]');
+      await expect(loginButton).toBeVisible();
+    });
+
+    test('登出后应隐藏登出按钮', async ({ page }) => {
+      // Arrange - 注册并登录
+      const testUser = {
+        username: generateUsername(),
+        email: generateEmail(),
+        password: 'TestPass123!',
+      };
+      await registerUser(page, testUser);
+
+      // 验证登出按钮可见
+      const logoutButtonBefore = page.locator(
+        'button.header-auth-logout, button:has-text("登出"), button:has-text("退出"), [data-testid="logout-button"]'
+      );
+      await expect(logoutButtonBefore).toBeVisible();
+
+      // Act - 点击登出按钮
+      await logoutUser(page);
+
+      // Assert - 登出按钮应不可见
+      await expect(logoutButtonBefore).not.toBeVisible();
+    });
+  });
+
+  // ========================================================================
+  // Token 清除测试
+  // ========================================================================
+
+  test.describe('Token 清除', () => {
+    test('登出后应清除 localStorage 中的 access_token', async ({ page }) => {
+      // Arrange - 注册并登录
+      const testUser = {
+        username: generateUsername(),
+        email: generateEmail(),
+        password: 'TestPass123!',
+      };
+      await registerUser(page, testUser);
+
+      // 验证 Token 存在
+      const hasTokenBefore = await page.evaluate(() => {
+        const tokens = localStorage.getItem('auth_tokens');
+        return !!tokens;
+      });
+      expect(hasTokenBefore).toBe(true);
+
+      // Act - 点击登出按钮
+      await logoutUser(page);
+
+      // Assert - Token 应被清除
+      const hasTokenAfter = await page.evaluate(() => {
+        const tokens = localStorage.getItem('auth_tokens');
+        return !!tokens;
+      });
+      expect(hasTokenAfter).toBe(false);
+    });
+
+    test('登出后应清除 localStorage 中的 refresh_token', async ({ page }) => {
+      // Arrange - 注册并登录
+      const testUser = {
+        username: generateUsername(),
+        email: generateEmail(),
+        password: 'TestPass123!',
+      };
+      await registerUser(page, testUser);
+
+      // 验证 refresh_token 存在
+      const hasRefreshTokenBefore = await page.evaluate(() => {
+        const tokens = localStorage.getItem('auth_tokens');
+        if (!tokens) return false;
+        try {
+          const parsed = JSON.parse(tokens);
+          return !!parsed.refresh_token;
+        } catch {
+          return false;
+        }
+      });
+      expect(hasRefreshTokenBefore).toBe(true);
+
+      // Act - 点击登出按钮
+      await logoutUser(page);
+
+      // Assert - refresh_token 应被清除
+      const hasRefreshTokenAfter = await page.evaluate(() => {
+        const tokens = localStorage.getItem('auth_tokens');
+        return !!tokens;
+      });
+      expect(hasRefreshTokenAfter).toBe(false);
+    });
+
+    test('登出后 getAuthState 应返回 unauthenticated', async ({ page }) => {
+      // Arrange - 注册并登录
+      const testUser = {
+        username: generateUsername(),
+        email: generateEmail(),
+        password: 'TestPass123!',
+      };
+      await registerUser(page, testUser);
+
+      // 验证已登录
+      const authStateBefore = await getAuthState(page);
+      expect(authStateBefore).toBe('authenticated');
+
+      // Act - 点击登出按钮
+      await logoutUser(page);
+
+      // Assert - 认证状态应为未登录
+      const authStateAfter = await getAuthState(page);
+      expect(authStateAfter).toBe('unauthenticated');
+    });
+  });
+
+  // ========================================================================
+  // 登出后路由行为测试
+  // ========================================================================
+
+  test.describe('登出后路由行为', () => {
+    test('登出后刷新页面应保持未登录状态', async ({ page }) => {
+      // Arrange - 注册并登录，然后登出
+      const testUser = {
+        username: generateUsername(),
+        email: generateEmail(),
+        password: 'TestPass123!',
+      };
+      await registerUser(page, testUser);
+      await logoutUser(page);
+
+      // Act - 刷新页面
+      await page.reload();
+
+      // Assert - 应显示登录按钮，不显示用户信息
+      const loginButton = page.locator('a[href="/login"]');
+      await expect(loginButton).toBeVisible();
+      const userInfo = page.locator('[data-testid="user-info"], .header-auth, .user-info');
+      await expect(userInfo).not.toBeVisible();
+    });
+
+    test('登出后访问首页应显示登录界面', async ({ page }) => {
+      // Arrange - 注册并登录，然后登出
+      const testUser = {
+        username: generateUsername(),
+        email: generateEmail(),
+        password: 'TestPass123!',
+      };
+      await registerUser(page, testUser);
+      await logoutUser(page);
+
+      // Act - 直接访问首页
+      await page.goto('/');
+
+      // Assert - 应重定向到登录页
+      await expect(page).toHaveURL('/login');
+    });
+  });
+
+  // ========================================================================
+  // 多次登出测试
+  // ========================================================================
+
+  test.describe('多次登出', () => {
+    test('多次登出不应报错', async ({ page }) => {
+      // Arrange - 注册并登录
+      const testUser = {
+        username: generateUsername(),
+        email: generateEmail(),
+        password: 'TestPass123!',
+      };
+      await registerUser(page, testUser);
+
+      // Act - 第一次登出
+      await logoutUser(page);
+
+      // Assert - 不应抛出错误
+      const authStateAfterFirst = await getAuthState(page);
+      expect(authStateAfterFirst).toBe('unauthenticated');
+
+      // Act - 尝试第二次登出（可能会找不到按钮）
+      // 这是边界情况，取决于前端实现
+      const logoutButton = page.locator(
+        'button.header-auth-logout, button:has-text("登出"), button:has-text("退出"), [data-testid="logout-button"]'
+      );
+      const isVisible = await logoutButton.isVisible().catch(() => false);
+
+      if (!isVisible) {
+        // 如果按钮不可见，这是预期行为
+        expect(isVisible).toBe(false);
+      } else {
+        // 如果按钮仍可见，尝试点击
+        await logoutUser(page);
+        const authStateAfterSecond = await getAuthState(page);
+        expect(authStateAfterSecond).toBe('unauthenticated');
+      }
+    });
+  });
+
+  // ========================================================================
+  // 跨标签页登出测试
+  // ========================================================================
+
+  test.describe('跨标签页登出', () => {
+    test('在一个标签页登出后，其他标签页也应登出', async ({ page, context }) => {
+      // Arrange - 在第一个标签页注册并登录
+      const testUser = {
+        username: generateUsername(),
+        email: generateEmail(),
+        password: 'TestPass123!',
+      };
+      await registerUser(page, testUser);
+
+      // 打开第二个标签页并导航到首页
+      const secondPage = await context.newPage();
+      await secondPage.goto('/');
+
+      // 验证第二个标签页也显示用户信息
+      const userInfoInSecond = secondPage.locator('[data-testid="user-info"], .header-auth, .user-info');
+      await expect(userInfoInSecond).toBeVisible();
+
+      // Act - 在第一个标签页登出
+      await logoutUser(page);
+
+      // Assert - 第二个标签页的用户信息应不可见
+      // 注意：这可能需要刷新页面或等待状态同步
+      await secondPage.reload();
+      await expect(userInfoInSecond).not.toBeVisible();
+
+      // 清理
+      await secondPage.close();
+    });
+  });
+});

--- a/frontend/e2e/specs/auth/register.spec.ts
+++ b/frontend/e2e/specs/auth/register.spec.ts
@@ -1,0 +1,325 @@
+/**
+ * 注册流程 E2E 测试
+ *
+ * 测试范围：
+ * 1. 表单验证（用户名、邮箱、密码规则）
+ * 2. 成功注册流程
+ * 3. 失败场景（重复用户名/邮箱）
+ *
+ * @see /workspace/frontend/e2e/helpers/auth-helpers.ts
+ * @see /workspace/frontend/e2e/pages/auth-pages.ts
+ */
+
+import { test, expect } from '@playwright/test';
+import { RegisterPage } from '../../pages/auth-pages';
+import { registerUser, clearAuth } from '../../helpers/auth-helpers';
+import {
+  VALID_USER,
+  VALID_MINIMAL,
+  VALID_MAXIMUM,
+  INVALID_SHORT_USERNAME,
+  INVALID_LONG_USERNAME,
+  INVALID_EMAIL_FORMAT,
+  INVALID_SHORT_PASSWORD,
+  INVALID_LONG_PASSWORD,
+  DUPLICATE_USERNAME,
+  DUPLICATE_EMAIL,
+  generateUsername,
+  generateEmail,
+} from '../../fixtures/auth/test-data';
+
+// ============================================================================
+// 注册流程测试套件
+// ============================================================================
+
+test.describe('注册流程', () => {
+  // 每个测试前清除认证状态
+  test.beforeEach(async ({ page }) => {
+    await clearAuth(page);
+  });
+
+  // ==========================================================================
+  // 表单验证测试
+  // ==========================================================================
+
+  test.describe('表单验证', () => {
+    test('应验证用户名最少 3 字符', async ({ page }) => {
+      const registerPage = new RegisterPage(page);
+      await registerPage.goto();
+
+      // 尝试注册用户名少于 3 字符的用户
+      await registerPage.register(
+        INVALID_SHORT_USERNAME.username,
+        INVALID_SHORT_USERNAME.email,
+        INVALID_SHORT_USERNAME.password
+      );
+
+      // 验证显示错误消息或仍在注册页面
+      const hasError = await registerPage.hasError();
+      const currentUrl = page.url();
+
+      expect(
+        hasError || currentUrl.includes('/register'),
+        '应显示错误或停留在注册页面'
+      ).toBeTruthy();
+    });
+
+    test('应验证用户名最多 50 字符', async ({ page }) => {
+      const registerPage = new RegisterPage(page);
+      await registerPage.goto();
+
+      // 尝试注册用户名超过 50 字符的用户
+      await registerPage.register(
+        INVALID_LONG_USERNAME.username,
+        INVALID_LONG_USERNAME.email,
+        INVALID_LONG_USERNAME.password
+      );
+
+      // 验证显示错误消息或仍在注册页面
+      const hasError = await registerPage.hasError();
+      const currentUrl = page.url();
+
+      expect(
+        hasError || currentUrl.includes('/register'),
+        '应显示错误或停留在注册页面'
+      ).toBeTruthy();
+    });
+
+    test('应验证邮箱格式', async ({ page }) => {
+      const registerPage = new RegisterPage(page);
+      await registerPage.goto();
+
+      // 尝试使用无效邮箱格式注册
+      await registerPage.register(
+        INVALID_EMAIL_FORMAT.username,
+        INVALID_EMAIL_FORMAT.email,
+        INVALID_EMAIL_FORMAT.password
+      );
+
+      // 验证显示错误消息或仍在注册页面
+      const hasError = await registerPage.hasError();
+      const currentUrl = page.url();
+
+      expect(
+        hasError || currentUrl.includes('/register'),
+        '应显示错误或停留在注册页面'
+      ).toBeTruthy();
+    });
+
+    test('应验证密码最少 8 字符', async ({ page }) => {
+      const registerPage = new RegisterPage(page);
+      await registerPage.goto();
+
+      // 尝试使用少于 8 字符的密码注册
+      await registerPage.register(
+        INVALID_SHORT_PASSWORD.username,
+        INVALID_SHORT_PASSWORD.email,
+        INVALID_SHORT_PASSWORD.password
+      );
+
+      // 验证显示错误消息或仍在注册页面
+      const hasError = await registerPage.hasError();
+      const currentUrl = page.url();
+
+      expect(
+        hasError || currentUrl.includes('/register'),
+        '应显示错误或停留在注册页面'
+      ).toBeTruthy();
+    });
+  });
+
+  // ==========================================================================
+  // 成功注册测试
+  // ==========================================================================
+
+  test.describe('成功注册', () => {
+    test('应成功注册新用户并自动登录', async ({ page }) => {
+      const uniqueUser = {
+        username: generateUsername(),
+        email: generateEmail(),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, uniqueUser, { autoLogin: true });
+
+      // 验证已跳转到首页
+      await expect(page).toHaveURL('/');
+
+      // 验证用户信息显示
+      const userInfo = page.locator('[data-testid="user-info"], .user-info, .header-auth');
+      await expect(userInfo).toBeVisible();
+    });
+
+    test('注册后应跳转到首页', async ({ page }) => {
+      const uniqueUser = {
+        username: generateUsername(),
+        email: generateEmail(),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, uniqueUser, { autoLogin: true });
+
+      // 验证 URL 已跳转到首页
+      await expect(page).toHaveURL('/');
+    });
+
+    test('注册后应显示用户信息', async ({ page }) => {
+      const uniqueUser = {
+        username: generateUsername(),
+        email: generateEmail(),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, uniqueUser, { autoLogin: true, verifyUserInfo: true });
+
+      // 验证用户信息显示在页面上
+      const userInfo = page.locator('[data-testid="user-info"], .user-info, .header-auth');
+      await expect(userInfo).toBeVisible();
+
+      // 验证用户名显示（可能在不同位置）
+      const pageContent = await page.content();
+      expect(pageContent).toContain(uniqueUser.username);
+    });
+
+    test('应接受最小长度的有效数据', async ({ page }) => {
+      const uniqueUser = {
+        username: 'abc', // 最少 3 字符
+        email: `test_${Date.now()}@a.co`,
+        password: '12345678', // 最少 8 字符
+      };
+
+      await registerUser(page, uniqueUser, { autoLogin: true });
+
+      // 验证注册成功
+      await expect(page).toHaveURL('/');
+    });
+
+    test('应接受最大长度的有效数据', async ({ page }) => {
+      const uniqueUser = {
+        username: 'a'.repeat(50), // 最多 50 字符
+        email: `test_${Date.now()}@example.com`,
+        password: 'a'.repeat(100), // 最多 100 字符
+      };
+
+      await registerUser(page, uniqueUser, { autoLogin: true });
+
+      // 验证注册成功
+      await expect(page).toHaveURL('/');
+    });
+  });
+
+  // ==========================================================================
+  // 失败场景测试
+  // ==========================================================================
+
+  test.describe('失败场景', () => {
+    test('应拒绝重复的用户名', async ({ page }) => {
+      // 首先注册一个用户
+      const existingUser = {
+        username: generateUsername('duplicate_test'),
+        email: generateEmail('original'),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, existingUser, { autoLogin: true });
+
+      // 清除认证状态
+      await clearAuth(page);
+
+      // 尝试使用相同用户名注册
+      const duplicateUsernameUser = {
+        username: existingUser.username, // 相同用户名
+        email: generateEmail('duplicate'),
+        password: 'TestPass123!',
+      };
+
+      const registerPage = new RegisterPage(page);
+      await registerPage.goto();
+      await registerPage.register(
+        duplicateUsernameUser.username,
+        duplicateUsernameUser.email,
+        duplicateUsernameUser.password
+      );
+
+      // 验证显示错误或仍在注册页面
+      const hasError = await registerPage.hasError();
+      const currentUrl = page.url();
+
+      expect(
+        hasError || currentUrl.includes('/register'),
+        '应显示错误或停留在注册页面'
+      ).toBeTruthy();
+
+      // 验证没有跳转到首页（注册失败）
+      await expect(page).not.toHaveURL('/');
+    });
+
+    test('应拒绝重复的邮箱', async ({ page }) => {
+      // 首先注册一个用户
+      const existingUser = {
+        username: generateUsername('email_test'),
+        email: `duplicate_${Date.now()}@example.com`,
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, existingUser, { autoLogin: true });
+
+      // 清除认证状态
+      await clearAuth(page);
+
+      // 尝试使用相同邮箱注册
+      const duplicateEmailUser = {
+        username: generateUsername('another'),
+        email: existingUser.email, // 相同邮箱
+        password: 'TestPass123!',
+      };
+
+      const registerPage = new RegisterPage(page);
+      await registerPage.goto();
+      await registerPage.register(
+        duplicateEmailUser.username,
+        duplicateEmailUser.email,
+        duplicateEmailUser.password
+      );
+
+      // 验证显示错误或仍在注册页面
+      const hasError = await registerPage.hasError();
+      const currentUrl = page.url();
+
+      expect(
+        hasError || currentUrl.includes('/register'),
+        '应显示错误或停留在注册页面'
+      ).toBeTruthy();
+
+      // 验证没有跳转到首页（注册失败）
+      await expect(page).not.toHaveURL('/');
+    });
+  });
+
+  // ==========================================================================
+  // UI 交互测试
+  // ==========================================================================
+
+  test.describe('UI 交互', () => {
+    test('应能从注册页面跳转到登录页面', async ({ page }) => {
+      const registerPage = new RegisterPage(page);
+      await registerPage.goto();
+      await registerPage.goToLogin();
+
+      // 验证已跳转到登录页面
+      await expect(page).toHaveURL(/\/login/);
+    });
+
+    test('注册页面应包含必要的表单元素', async ({ page }) => {
+      const registerPage = new RegisterPage(page);
+      await registerPage.goto();
+
+      // 验证所有表单元素存在
+      await expect(registerPage.usernameInput).toBeVisible();
+      await expect(registerPage.emailInput).toBeVisible();
+      await expect(registerPage.passwordInput).toBeVisible();
+      await expect(registerPage.submitButton).toBeVisible();
+      await expect(registerPage.loginLink).toBeVisible();
+    });
+  });
+});

--- a/frontend/e2e/specs/auth/route-protection.spec.ts
+++ b/frontend/e2e/specs/auth/route-protection.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * 路由保护 E2E 测试
+ *
+ * 验收标准覆盖：
+ * AC1: 未登录用户访问受保护页面应重定向到登录页
+ * AC2: 已登录用户访问认证页面应重定向到首页
+ *
+ * @module e2e/specs/auth/route-protection
+ */
+
+import { test, expect } from '@playwright/test';
+import { RegisterPage, LoginPage } from '../../pages/auth-pages';
+import { registerUser, clearAuth } from '../../helpers/auth-helpers';
+import { generateUsername, generateEmail } from '../../fixtures/auth/test-data';
+
+test.describe('路由保护', () => {
+  // 每个测试前清除认证状态
+  test.beforeEach(async ({ page }) => {
+    await clearAuth(page);
+  });
+
+  // ========================================================================
+  // 未登录重定向测试
+  // ========================================================================
+
+  test.describe('未登录重定向', () => {
+    test('未登录访问首页应重定向到登录页', async ({ page }) => {
+      // Act - 直接访问首页
+      await page.goto('/');
+
+      // Assert - 应重定向到登录页
+      await expect(page).toHaveURL('/login');
+    });
+
+    test('未登录访问受保护路由应显示登录按钮', async ({ page }) => {
+      // Act - 直接访问首页
+      await page.goto('/');
+
+      // Assert - 应显示登录按钮
+      const loginButton = page.locator('a[href="/login"]');
+      await expect(loginButton).toBeVisible();
+    });
+
+    test('未登录访问受保护路由不应显示用户信息', async ({ page }) => {
+      // Act - 直接访问首页
+      await page.goto('/');
+
+      // Assert - 不应显示用户信息
+      const userInfo = page.locator('[data-testid="user-info"], .header-auth, .user-info');
+      await expect(userInfo).not.toBeVisible();
+    });
+  });
+
+  // ========================================================================
+  // 已登录重定向测试
+  // ========================================================================
+
+  test.describe('已登录重定向', () => {
+    test.beforeEach(async ({ page }) => {
+      // 注册并登录用户
+      const testUser = {
+        username: generateUsername(),
+        email: generateEmail(),
+        password: 'TestPass123!',
+      };
+      await registerUser(page, testUser);
+    });
+
+    test('已登录访问登录页应重定向到首页', async ({ page }) => {
+      // Act - 已登录用户访问登录页
+      await page.goto('/login');
+
+      // Assert - 应重定向到首页
+      await expect(page).toHaveURL('/');
+    });
+
+    test('已登录访问注册页应重定向到首页', async ({ page }) => {
+      // Act - 已登录用户访问注册页
+      await page.goto('/register');
+
+      // Assert - 应重定向到首页
+      await expect(page).toHaveURL('/');
+    });
+
+    test('已登录访问首页应正常显示', async ({ page }) => {
+      // Act - 已登录用户访问首页
+      await page.goto('/');
+
+      // Assert - 应显示在首页
+      await expect(page).toHaveURL('/');
+      const userInfo = page.locator('[data-testid="user-info"], .header-auth, .user-info');
+      await expect(userInfo).toBeVisible();
+    });
+
+    test('已登录用户不应看到登录按钮', async ({ page }) => {
+      // Act - 已登录用户访问首页
+      await page.goto('/');
+
+      // Assert - 不应显示登录按钮
+      const loginButton = page.locator('a[href="/login"]');
+      await expect(loginButton).not.toBeVisible();
+    });
+
+    test('已登录用户应看到登出按钮', async ({ page }) => {
+      // Act - 已登录用户访问首页
+      await page.goto('/');
+
+      // Assert - 应显示登出按钮
+      const logoutButton = page.locator(
+        'button.header-auth-logout, button:has-text("登出"), button:has-text("退出"), [data-testid="logout-button"]'
+      );
+      await expect(logoutButton).toBeVisible();
+    });
+  });
+
+  // ========================================================================
+  // 登出后重定向测试
+  // ========================================================================
+
+  test.describe('登出后重定向', () => {
+    test('登出后访问首页应重定向到登录页', async ({ page }) => {
+      // Arrange - 注册并登录，然后登出
+      const testUser = {
+        username: generateUsername(),
+        email: generateEmail(),
+        password: 'TestPass123!',
+      };
+      await registerUser(page, testUser);
+      await clearAuth(page);
+
+      // Act - 访问首页
+      await page.goto('/');
+
+      // Assert - 应重定向到登录页
+      await expect(page).toHaveURL('/login');
+    });
+
+    test('登出后应显示登录按钮', async ({ page }) => {
+      // Arrange - 注册并登录，然后登出
+      const testUser = {
+        username: generateUsername(),
+        email: generateEmail(),
+        password: 'TestPass123!',
+      };
+      await registerUser(page, testUser);
+      await clearAuth(page);
+
+      // Act - 访问首页
+      await page.goto('/');
+
+      // Assert - 应显示登录按钮
+      const loginButton = page.locator('a[href="/login"]');
+      await expect(loginButton).toBeVisible();
+    });
+  });
+
+  // ========================================================================
+  // 路由过渡测试
+  // ========================================================================
+
+  test.describe('路由过渡', () => {
+    test('从登录页到首页的过渡应正常', async ({ page }) => {
+      // Arrange - 清除状态
+      await clearAuth(page);
+      const loginPage = new LoginPage(page);
+      await loginPage.goto();
+
+      // Act - 登录
+      const testUser = {
+        username: generateUsername(),
+        email: generateEmail(),
+        password: 'TestPass123!',
+      };
+      // 先注册用户
+      await registerUser(page, testUser);
+      await clearAuth(page);
+      // 再登录
+      await loginPage.goto();
+      await loginPage.login(testUser.username, testUser.password);
+
+      // Assert - 应成功过渡到首页
+      await expect(page).toHaveURL('/');
+      const userInfo = page.locator('[data-testid="user-info"], .header-auth, .user-info');
+      await expect(userInfo).toBeVisible();
+    });
+  });
+});

--- a/frontend/e2e/specs/auth/token-persistence.spec.ts
+++ b/frontend/e2e/specs/auth/token-persistence.spec.ts
@@ -1,0 +1,405 @@
+/**
+ * Token 持久化 E2E 测试
+ *
+ * 测试范围：
+ * 1. 刷新页面后保持登录状态
+ * 2. Token 正确存储到 localStorage
+ * 3. Token 过期后自动刷新
+ *
+ * @see /workspace/frontend/e2e/helpers/auth-helpers.ts
+ * @see /workspace/frontend/e2e/pages/auth-pages.ts
+ */
+
+import { test, expect } from '@playwright/test';
+import { registerUser, loginUser, clearAuth, getAuthState, waitForAuthState } from '../../helpers/auth-helpers';
+import { generateUsername, generateEmail } from '../../fixtures/auth/test-data';
+
+// ============================================================================
+// Token 持久化测试套件
+// ============================================================================
+
+test.describe('Token 持久化', () => {
+  // 每个测试前清除认证状态
+  test.beforeEach(async ({ page }) => {
+    await clearAuth(page);
+  });
+
+  // ==========================================================================
+  // 页面刷新持久化测试
+  // ==========================================================================
+
+  test.describe('页面刷新持久化', () => {
+    test('刷新页面后应保持登录状态', async ({ page }) => {
+      // 创建并登录用户
+      const testUser = {
+        username: generateUsername('refresh_test'),
+        email: generateEmail('refresh_test'),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, testUser, { autoLogin: true });
+
+      // 验证初始登录状态
+      let authState = await getAuthState(page);
+      expect(authState).toBe('authenticated');
+
+      // 验证用户信息显示
+      const userInfo = page.locator('[data-testid="user-info"], .user-info, .header-auth');
+      await expect(userInfo).toBeVisible();
+
+      // 刷新页面
+      await page.reload();
+
+      // 验证刷新后仍保持登录状态
+      authState = await getAuthState(page);
+      expect(authState).toBe('authenticated');
+
+      // 验证用户信息仍然显示
+      await expect(userInfo).toBeVisible();
+    });
+
+    test('多次刷新页面后应保持登录状态', async ({ page }) => {
+      // 创建并登录用户
+      const testUser = {
+        username: generateUsername('multi_refresh'),
+        email: generateEmail('multi_refresh'),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, testUser, { autoLogin: true });
+
+      // 多次刷新页面
+      for (let i = 0; i < 3; i++) {
+        await page.reload();
+
+        // 验证每次刷新后仍保持登录状态
+        const authState = await getAuthState(page);
+        expect(authState).toBe('authenticated');
+
+        const userInfo = page.locator('[data-testid="user-info"], .user-info, .header-auth');
+        await expect(userInfo).toBeVisible();
+      }
+    });
+
+    test('刷新后应能访问需要认证的页面', async ({ page }) => {
+      // 创建并登录用户
+      const testUser = {
+        username: generateUsername('access_test'),
+        email: generateEmail('access_test'),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, testUser, { autoLogin: true });
+
+      // 刷新页面
+      await page.reload();
+
+      // 验证仍在首页（需要认证的页面）
+      await expect(page).toHaveURL('/');
+
+      // 验证用户信息显示
+      const userInfo = page.locator('[data-testid="user-info"], .user-info, .header-auth');
+      await expect(userInfo).toBeVisible();
+    });
+  });
+
+  // ==========================================================================
+  // Token 存储测试
+  // ==========================================================================
+
+  test.describe('Token 存储', () => {
+    test('应正确存储 access_token 到 localStorage', async ({ page }) => {
+      const testUser = {
+        username: generateUsername('access_token'),
+        email: generateEmail('access_token'),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, testUser, { autoLogin: true });
+
+      // 验证 access_token 存在
+      const hasAccessToken = await page.evaluate(() => {
+        const tokens = localStorage.getItem('auth_tokens');
+        if (!tokens) return false;
+
+        try {
+          const parsed = JSON.parse(tokens);
+          return !!parsed.access_token && typeof parsed.access_token === 'string';
+        } catch {
+          return false;
+        }
+      });
+
+      expect(hasAccessToken).toBeTruthy();
+    });
+
+    test('应正确存储 refresh_token 到 localStorage', async ({ page }) => {
+      const testUser = {
+        username: generateUsername('refresh_token'),
+        email: generateEmail('refresh_token'),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, testUser, { autoLogin: true });
+
+      // 验证 refresh_token 存在
+      const hasRefreshToken = await page.evaluate(() => {
+        const tokens = localStorage.getItem('auth_tokens');
+        if (!tokens) return false;
+
+        try {
+          const parsed = JSON.parse(tokens);
+          return !!parsed.refresh_token && typeof parsed.refresh_token === 'string';
+        } catch {
+          return false;
+        }
+      });
+
+      expect(hasRefreshToken).toBeTruthy();
+    });
+
+    test('Token 应包含必要的字段', async ({ page }) => {
+      const testUser = {
+        username: generateUsername('token_fields'),
+        email: generateEmail('token_fields'),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, testUser, { autoLogin: true });
+
+      // 验证 Token 结构
+      const tokenStructure = await page.evaluate(() => {
+        const tokens = localStorage.getItem('auth_tokens');
+        if (!tokens) return null;
+
+        try {
+          const parsed = JSON.parse(tokens);
+          return {
+            hasAccessToken: !!parsed.access_token,
+            hasRefreshToken: !!parsed.refresh_token,
+            hasTokenType: !!parsed.token_type,
+            accessTokenType: typeof parsed.access_token,
+            refreshTokenType: typeof parsed.refresh_token,
+          };
+        } catch {
+          return null;
+        }
+      });
+
+      expect(tokenStructure).not.toBeNull();
+      expect(tokenStructure?.hasAccessToken).toBeTruthy();
+      expect(tokenStructure?.hasRefreshToken).toBeTruthy();
+      expect(tokenStructure?.accessTokenType).toBe('string');
+      expect(tokenStructure?.refreshTokenType).toBe('string');
+    });
+  });
+
+  // ==========================================================================
+  // Token 生命周期测试
+  // ==========================================================================
+
+  test.describe('Token 生命周期', () => {
+    test('Token 应在登录后创建', async ({ page }) => {
+      const testUser = {
+        username: generateUsername('token_create'),
+        email: generateEmail('token_create'),
+        password: 'TestPass123!',
+      };
+
+      // 先注册
+      await registerUser(page, testUser, { autoLogin: true });
+
+      // 验证 Token 存在
+      const authState = await getAuthState(page);
+      expect(authState).toBe('authenticated');
+
+      // 清除并重新登录
+      await clearAuth(page);
+
+      let hasTokens = await page.evaluate(() => !!localStorage.getItem('auth_tokens'));
+      expect(hasTokens).toBeFalsy();
+
+      // 重新登录
+      await loginUser(page, {
+        usernameOrEmail: testUser.username,
+        password: testUser.password,
+      });
+
+      // 验证 Token 重新创建
+      hasTokens = await page.evaluate(() => !!localStorage.getItem('auth_tokens'));
+      expect(hasTokens).toBeTruthy();
+    });
+
+    test('Token 应在登出后清除', async ({ page }) => {
+      const testUser = {
+        username: generateUsername('token_clear'),
+        email: generateEmail('token_clear'),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, testUser, { autoLogin: true });
+
+      // 验证 Token 存在
+      let hasTokens = await page.evaluate(() => !!localStorage.getItem('auth_tokens'));
+      expect(hasTokens).toBeTruthy();
+
+      // 登出
+      await page.click('button.header-auth-logout, button:has-text("登出"), button:has-text("退出"), [data-testid="logout-button"]');
+
+      // 等待登出完成
+      await page.waitForTimeout(1000);
+
+      // 验证 Token 已清除
+      hasTokens = await page.evaluate(() => !!localStorage.getItem('auth_tokens'));
+      expect(hasTokens).toBeFalsy();
+    });
+
+    test('清除 localStorage 后应变为未认证状态', async ({ page }) => {
+      const testUser = {
+        username: generateUsername('clear_state'),
+        email: generateEmail('clear_state'),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, testUser, { autoLogin: true });
+
+      // 验证已认证
+      let authState = await getAuthState(page);
+      expect(authState).toBe('authenticated');
+
+      // 清除 localStorage
+      await clearAuth(page);
+
+      // 验证变为未认证状态
+      authState = await getAuthState(page);
+      expect(authState).toBe('unauthenticated');
+
+      // 刷新页面
+      await page.reload();
+
+      // 验证被重定向到登录页面
+      await page.waitForURL(/\/login/, { timeout: 5000 }).catch(() => {
+        // 可能重定向到首页或其他页面，这也是可接受的
+      });
+    });
+  });
+
+  // ==========================================================================
+  // Token 刷新测试
+  // ==========================================================================
+
+  test.describe('Token 自动刷新', () => {
+    test('应使用 refresh_token 刷新 access_token', async ({ page }) => {
+      const testUser = {
+        username: generateUsername('auto_refresh'),
+        email: generateEmail('auto_refresh'),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, testUser, { autoLogin: true });
+
+      // 获取原始 Token
+      const originalTokens = await page.evaluate(() => {
+        const tokens = localStorage.getItem('auth_tokens');
+        return tokens ? JSON.parse(tokens) : null;
+      });
+
+      expect(originalTokens).not.toBeNull();
+      expect(originalTokens?.access_token).toBeTruthy();
+
+      // 模拟 Token 过期（手动清除 access_token，保留 refresh_token）
+      await page.evaluate(() => {
+        const tokens = localStorage.getItem('auth_tokens');
+        if (tokens) {
+          const parsed = JSON.parse(tokens);
+          delete parsed.access_token;
+          localStorage.setItem('auth_tokens', JSON.stringify(parsed));
+        }
+      });
+
+      // 刷新页面触发 Token 刷新
+      await page.reload();
+
+      // 等待 Token 刷新
+      await page.waitForTimeout(2000);
+
+      // 验证 access_token 已刷新
+      const newTokens = await page.evaluate(() => {
+        const tokens = localStorage.getItem('auth_tokens');
+        return tokens ? JSON.parse(tokens) : null;
+      });
+
+      // Token 应该已被刷新（access_token 重新存在）
+      expect(newTokens?.access_token).toBeTruthy();
+    });
+
+    test('Token 刷新后应保持认证状态', async ({ page }) => {
+      const testUser = {
+        username: generateUsername('refresh_auth'),
+        email: generateEmail('refresh_auth'),
+        password: 'TestPass123!',
+      };
+
+      await registerUser(page, testUser, { autoLogin: true });
+
+      // 验证初始认证状态
+      let authState = await getAuthState(page);
+      expect(authState).toBe('authenticated');
+
+      // 刷新页面
+      await page.reload();
+
+      // 等待可能的 Token 刷新
+      await page.waitForTimeout(1000);
+
+      // 验证仍保持认证状态
+      authState = await getAuthState(page);
+      expect(authState).toBe('authenticated');
+
+      // 验证用户信息仍然显示
+      const userInfo = page.locator('[data-testid="user-info"], .user-info, .header-auth');
+      await expect(userInfo).toBeVisible();
+    });
+  });
+
+  // ==========================================================================
+  // 跨标签页持久化测试
+  // ==========================================================================
+
+  test.describe('跨标签页持久化', () => {
+    test('新标签页应能读取已存储的 Token', async ({ browser }) => {
+      const testUser = {
+        username: generateUsername('multi_tab'),
+        email: generateEmail('multi_tab'),
+        password: 'TestPass123!',
+      };
+
+      // 第一个标签页：登录
+      const page1 = await browser.newPage();
+      await registerUser(page1, testUser, { autoLogin: true });
+
+      // 验证第一个标签页已登录
+      let authState = await getAuthState(page1);
+      expect(authState).toBe('authenticated');
+
+      // 第二个标签页：访问首页
+      const page2 = await browser.newPage();
+      await page2.goto('/');
+
+      // 等待可能的导航或状态检查
+      await page2.waitForTimeout(1000);
+
+      // 验证第二个标签页的认证状态
+      // 注意：localStorage 在同一域名下的标签页是共享的
+      authState = await getAuthState(page2);
+      // 新标签页应该能读取到 Token，但可能需要重新初始化认证状态
+      const hasTokens = await page2.evaluate(() => !!localStorage.getItem('auth_tokens'));
+
+      expect(hasTokens).toBeTruthy();
+
+      // 清理
+      await page1.close();
+      await page2.close();
+    });
+  });
+});


### PR DESCRIPTION
## 概述
实现覆盖认证流程的 5 个端到端测试场景，共 59 个测试用例。

## 变更内容

### 新增测试文件
- **register.spec.ts** (325 行, 13 个测试用例)
  - 表单验证（用户名长度、邮箱格式、密码长度）
  - 成功注册与自动登录
  - 重复用户名/邮箱失败场景

- **login.spec.ts** (324 行, 13 个测试用例)
  - 用户名/邮箱登录
  - 错误凭据处理
  - 登录状态验证

- **token-persistence.spec.ts** (405 行, 12 个测试用例)
  - 刷新页面保持登录状态
  - Token localStorage 存储
  - 跨标签页状态同步

- **route-protection.spec.ts** (187 行, 11 个测试用例)
  - 未登录重定向到登录页
  - 已登录访问认证页重定向
  - 登出后路由行为

- **logout.spec.ts** (289 行, 10 个测试用例)
  - 清除认证状态
  - 清除 localStorage Token
  - 跨标签页登出

### 新增测试数据
- **test-data.ts** - 有效/无效/边界值测试数据 fixtures

## 测试覆盖
- ✅ 注册流程（表单验证、成功/失败场景）
- ✅ 登录流程（用户名/邮箱登录、错误处理）
- ✅ Token 持久化（刷新页面、localStorage、跨标签页）
- ✅ 路由保护（未登录/已登录重定向）
- ✅ 登出流程（状态清除、Token 清理）

## 测试计划
- [ ] CI E2E 测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Relates to #138