### PR TITLE
feat: 实现用户资料更新 API 端点 (Issue #170)

### DIFF
--- a/src/backend/app/api/v1/auth.py
+++ b/src/backend/app/api/v1/auth.py
@@ -12,7 +12,13 @@ from ...core.exceptions import ConflictError
 from ...core.security import SecurityService
 from ...models.user import User
 from ...repositories.user import UserRepository
-from ...schemas.auth import LoginRequest, RefreshRequest, RegisterRequest, UserResponse
+from ...schemas.auth import (
+    LoginRequest,
+    RefreshRequest,
+    RegisterRequest,
+    UserResponse,
+    UserUpdateRequest,
+)
 from ...services.auth import AuthService, TokenResponse
 from ..deps import (
     get_auth_service,
@@ -307,5 +313,84 @@ async def get_current_user_info(
     3. 查询用户信息（由 get_current_user 依赖完成）
     4. 返回用户信息
     """
+    response: UserResponse = UserResponse.model_validate(current_user)
+    return response
+
+
+@router.patch(
+    "/me",
+    response_model=UserResponse,
+    status_code=status.HTTP_200_OK,
+    summary="更新当前用户信息",
+    description="更新当前认证用户的基本信息（用户名或邮箱），需要提供有效的 JWT Token",
+    responses={
+        400: {
+            "description": "请求体验证失败",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "detail": "Validation error",
+                        "errors": [
+                            {
+                                "loc": ["body", "username"],
+                                "msg": "String should have at least 3 characters",
+                                "type": "string_too_short",
+                            }
+                        ],
+                    }
+                }
+            },
+        },
+        401: {
+            "description": "未认证或 Token 无效",
+            "content": {"application/json": {"example": {"detail": "Invalid token"}}},
+        },
+        409: {
+            "description": "用户名或邮箱已存在",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "detail": "Username already exists",
+                        "field": "username",
+                    }
+                }
+            },
+        },
+    },
+)
+async def update_current_user(
+    request: UserUpdateRequest,
+    current_user: User = Depends(get_current_user),
+    user_repo: UserRepository = Depends(get_user_repository),
+    session: AsyncSession = Depends(get_db_session),
+) -> UserResponse:
+    """更新当前用户信息端点
+
+    业务逻辑：
+    1. 验证请求体（Pydantic 自动验证）
+    2. 从 JWT Token 中获取当前用户（由 get_current_user 依赖完成）
+    3. 检查用户名是否已被其他用户使用（如果更新用户名）
+    4. 检查邮箱是否已被其他用户使用（如果更新邮箱）
+    5. 更新用户信息
+    6. 保存到数据库
+    7. 返回更新后的用户信息
+    """
+    # 检查用户名是否已被其他用户使用
+    if request.username is not None and request.username != current_user.username:
+        if await user_repo.username_exists(request.username):
+            raise ConflictError("Username already exists", extra={"field": "username"})
+        current_user.username = request.username
+
+    # 检查邮箱是否已被其他用户使用
+    if request.email is not None and request.email != current_user.email:
+        if await user_repo.email_exists(request.email):
+            raise ConflictError("Email already exists", extra={"field": "email"})
+        current_user.email = request.email
+
+    # 保存到数据库
+    await session.commit()
+    await session.refresh(current_user)
+
+    # 返回更新后的用户信息
     response: UserResponse = UserResponse.model_validate(current_user)
     return response

--- a/src/backend/app/core/security.py
+++ b/src/backend/app/core/security.py
@@ -107,7 +107,7 @@ class SecurityService:
         salt = bcrypt.gensalt(rounds=self._rounds, prefix=b"2b")
         hashed = bcrypt.hashpw(password_bytes, salt)
 
-        return hashed.decode("utf-8")
+        return str(hashed.decode("utf-8"))
 
     def verify_password(self, plain_password: str, hashed_password: str) -> bool:
         """验证密码
@@ -126,7 +126,7 @@ class SecurityService:
         try:
             password_bytes = plain_password.encode("utf-8")[:72]
             hashed_bytes = hashed_password.encode("utf-8")
-            return bcrypt.checkpw(password_bytes, hashed_bytes)
+            return bool(bcrypt.checkpw(password_bytes, hashed_bytes))
         except Exception:
             # 哈希格式错误或其他异常，统一返回 False
             return False
@@ -261,11 +261,12 @@ class JWTService:
         Returns:
             str: JWT Token 字符串
         """
-        return jwt.encode(
+        token: str = jwt.encode(
             payload,
             self._settings.jwt_secret_key,
             algorithm=self._settings.jwt_algorithm,
         )
+        return token
 
     # ==================== Token 解析与验证 ====================
 
@@ -283,7 +284,7 @@ class JWTService:
             TokenExpiredError: Token 已过期
         """
         try:
-            payload = jwt.decode(
+            payload: dict[str, Any] = jwt.decode(
                 token,
                 self._settings.jwt_secret_key,
                 algorithms=[self._settings.jwt_algorithm],
@@ -404,7 +405,8 @@ class JWTService:
         """
         try:
             payload = jwt.get_unverified_claims(token)
-            return payload.get("sub", "")
+            user_id: str = payload.get("sub", "")
+            return user_id
         except JWTError as e:
             raise InvalidTokenError(f"Cannot extract user_id: {str(e)}") from e
 

--- a/src/backend/app/schemas/auth.py
+++ b/src/backend/app/schemas/auth.py
@@ -69,6 +69,37 @@ class RefreshRequest(BaseModel):
     refresh_token: str = Field(..., min_length=1, description="刷新 Token")
 
 
+class UserUpdateRequest(BaseModel):
+    """用户资料更新请求模型
+
+    用于更新用户名和邮箱，所有字段均为可选
+    但至少需要提供其中一个字段
+
+    Attributes:
+        username (str | None): 用户名，3-50 字符
+        email (EmailStr | None): 邮箱地址
+    """
+
+    username: str | None = Field(
+        default=None, min_length=3, max_length=50, description="用户名"
+    )
+    email: EmailStr | None = Field(default=None, description="邮箱地址")
+
+    @model_validator(mode="after")
+    def validate_at_least_one_field(self) -> "UserUpdateRequest":
+        """验证至少提供一个字段用于更新
+
+        Returns:
+            验证通过的实例
+
+        Raises:
+            ValueError: 当 username 和 email 均为 None 时抛出
+        """
+        if self.username is None and self.email is None:
+            raise ValueError("至少需要提供一个字段进行更新（username 或 email）")
+        return self
+
+
 class UserResponse(BaseModel):
     """用户信息响应模型
 

--- a/src/backend/app/services/auth.py
+++ b/src/backend/app/services/auth.py
@@ -194,7 +194,8 @@ class AuthService:
             InvalidTokenError: Token 无效
             TokenExpiredError: Token 已过期
         """
-        return self._jwt.verify_access_token(token)
+        payload: dict[str, Any] = self._jwt.verify_access_token(token)
+        return payload
 
 
 # ==================== 模块导出 ====================

--- a/tests/backend/test_auth_refresh_routes.py
+++ b/tests/backend/test_auth_refresh_routes.py
@@ -21,12 +21,12 @@ class TestRefreshRouterDefinition:
     def test_refresh_endpoint_exists(self):
         """测试刷新端点存在
 
-        验证路由数量从 3 增加到 4
+        验证路由数量从 3 增加到 5（新增 refresh 和 update 端点）
         """
         # 原有路由: /register, /login, /me (3个)
         # 新增路由: /refresh (1个)
-        # 总数应该是 4
-        assert len(router.routes) == 4
+        # 总数应该是 5
+        assert len(router.routes) == 5
 
     def test_refresh_endpoint_path(self):
         """测试刷新端点路径正确"""

--- a/tests/backend/test_config.py
+++ b/tests/backend/test_config.py
@@ -24,21 +24,22 @@ from src.backend.app.core.config import Settings, get_settings
 class TestSettingsModel:
     """测试 Settings 模型的基础功能"""
 
-    def test_settings_with_default_values(self):
+    def test_settings_with_default_values(self, monkeypatch):
         """测试使用默认值创建 Settings"""
         # 确保环境变量未设置
-        env_vars = ["APP_NAME", "APP_VERSION", "DEBUG", "API_PREFIX"]
+        env_vars = ["APP_NAME", "APP_VERSION", "DEBUG", "API_PREFIX", "ENVIRONMENT"]
         for var in env_vars:
-            if var in os.environ:
-                del os.environ[var]
+            monkeypatch.delenv(var, raising=False)
 
-        settings = Settings()
+        # 创建 Settings 时忽略 .env 文件
+        settings = Settings(_env_file=None)
 
         # 验证默认值
         assert settings.app_name == "Scryer"
         assert settings.app_version == "0.1.0"
         assert settings.debug is False
         assert settings.api_prefix == "/api"
+        assert settings.environment == "production"
 
     def test_settings_from_environment_variables(self):
         """测试从环境变量加载配置"""
@@ -91,7 +92,10 @@ class TestSettingsModel:
             Settings(secret_key="short")
 
         # 验证错误信息包含最少长度要求
-        assert "at least 32 characters" in str(exc_info.value).lower() or "min_length" in str(exc_info.value).lower()
+        assert (
+            "at least 32 characters" in str(exc_info.value).lower()
+            or "min_length" in str(exc_info.value).lower()
+        )
 
     def test_settings_valid_secret_key(self):
         """测试有效的 SECRET_KEY"""
@@ -103,7 +107,10 @@ class TestSettingsModel:
         """测试 CORS 源的默认值"""
         settings = Settings()
         # 默认应该只允许 localhost
-        assert "http://localhost:3000" in settings.cors_origins or settings.cors_origins == []
+        assert (
+            "http://localhost:3000" in settings.cors_origins
+            or settings.cors_origins == []
+        )
 
     def test_settings_cors_origins_custom(self):
         """测试自定义 CORS 源"""

--- a/tests/backend/test_schemas_user_update.py
+++ b/tests/backend/test_schemas_user_update.py
@@ -1,0 +1,195 @@
+"""用户资料更新 Schema 测试
+
+测试范围：
+- UserUpdateRequest 模型验证
+- 边界值测试
+- 错误消息测试
+
+契约来源：Issue #170 - src/backend/app/schemas/auth.py 中的 UserUpdateRequest
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from src.backend.app.schemas.auth import UserUpdateRequest
+
+
+class TestUserUpdateRequestValid:
+    """测试 UserUpdateRequest 有效输入"""
+
+    def test_update_username_only(self):
+        """测试仅更新 username 成功"""
+        request = UserUpdateRequest(username="new_username")
+        assert request.username == "new_username"
+        assert request.email is None
+
+    def test_update_email_only(self):
+        """测试仅更新 email 成功"""
+        request = UserUpdateRequest(email="new@example.com")
+        assert request.username is None
+        assert request.email == "new@example.com"
+
+    def test_update_both_fields(self):
+        """测试同时更新 username 和 email 成功"""
+        request = UserUpdateRequest(username="new_username", email="new@example.com")
+        assert request.username == "new_username"
+        assert request.email == "new@example.com"
+
+    def test_username_boundary_min_length(self):
+        """测试 username 长度为最小值 3 时成功"""
+        request = UserUpdateRequest(username="abc")
+        assert request.username == "abc"
+
+    def test_username_boundary_max_length(self):
+        """测试 username 长度为最大值 50 时成功"""
+        username = "a" * 50
+        request = UserUpdateRequest(username=username)
+        assert request.username == username
+        assert len(request.username) == 50
+
+    def test_valid_email_formats(self):
+        """测试各种有效邮箱格式"""
+        valid_emails = [
+            "test@example.com",
+            "user.name@domain.co.uk",
+            "user+tag@test.com",
+            "user123@test-domain.com",
+        ]
+        for email in valid_emails:
+            request = UserUpdateRequest(email=email)
+            assert request.email == email
+
+
+class TestUserUpdateRequestInvalid:
+    """测试 UserUpdateRequest 无效输入"""
+
+    def test_no_fields_provided(self):
+        """测试未提供任何更新字段时抛出 ValidationError"""
+        with pytest.raises(ValidationError) as exc_info:
+            UserUpdateRequest()
+
+        errors = exc_info.value.errors()
+        assert any("至少需要提供一个字段进行更新" in str(e) for e in errors)
+
+    def test_explicit_none_values(self):
+        """测试显式传入 None 值时抛出 ValidationError"""
+        with pytest.raises(ValidationError) as exc_info:
+            UserUpdateRequest(username=None, email=None)
+
+        errors = exc_info.value.errors()
+        assert any("至少需要提供一个字段进行更新" in str(e) for e in errors)
+
+    def test_username_too_short(self):
+        """测试 username 长度小于 3 时抛出 ValidationError"""
+        with pytest.raises(ValidationError) as exc_info:
+            UserUpdateRequest(username="ab")
+
+        errors = exc_info.value.errors()
+        assert any(e["loc"] == ("username",) for e in errors)
+        assert any("3" in str(e.get("msg", "")) for e in errors)
+
+    def test_username_too_long(self):
+        """测试 username 长度大于 50 时抛出 ValidationError"""
+        with pytest.raises(ValidationError) as exc_info:
+            UserUpdateRequest(username="a" * 51)
+
+        errors = exc_info.value.errors()
+        assert any(e["loc"] == ("username",) for e in errors)
+        assert any("50" in str(e.get("msg", "")) for e in errors)
+
+    def test_invalid_email_format(self):
+        """测试无效邮箱格式时抛出 ValidationError"""
+        invalid_emails = [
+            "invalid-email",
+            "missing@",
+            "@missing.local",
+            "spaces in@email.com",
+            "no-at-sign.com",
+        ]
+        for email in invalid_emails:
+            with pytest.raises(ValidationError) as exc_info:
+                UserUpdateRequest(email=email)
+
+            errors = exc_info.value.errors()
+            assert any(e["loc"] == ("email",) for e in errors)
+
+    def test_username_empty_string(self):
+        """测试 username 为空字符串时抛出 ValidationError"""
+        with pytest.raises(ValidationError) as exc_info:
+            UserUpdateRequest(username="")
+
+        errors = exc_info.value.errors()
+        assert any(e["loc"] == ("username",) for e in errors)
+
+
+class TestUserUpdateRequestSerialization:
+    """测试 UserUpdateRequest 序列化"""
+
+    def test_model_dump_with_username(self):
+        """测试仅包含 username 时序列化为字典"""
+        request = UserUpdateRequest(username="test_user")
+        data = request.model_dump()
+
+        assert data["username"] == "test_user"
+        assert data["email"] is None
+
+    def test_model_dump_with_email(self):
+        """测试仅包含 email 时序列化为字典"""
+        request = UserUpdateRequest(email="test@example.com")
+        data = request.model_dump()
+
+        assert data["username"] is None
+        assert data["email"] == "test@example.com"
+
+    def test_model_dump_with_both(self):
+        """测试包含两个字段时序列化为字典"""
+        request = UserUpdateRequest(username="test_user", email="test@example.com")
+        data = request.model_dump()
+
+        assert data["username"] == "test_user"
+        assert data["email"] == "test@example.com"
+
+    def test_model_dump_json(self):
+        """测试 JSON 序列化"""
+        request = UserUpdateRequest(username="test_user", email="test@example.com")
+        json_data = request.model_dump_json()
+
+        assert "test_user" in json_data
+        assert "test@example.com" in json_data
+
+
+class TestUserUpdateRequestEdgeCases:
+    """测试 UserUpdateRequest 边界情况"""
+
+    def test_username_with_special_characters(self):
+        """测试 username 包含特殊字符（连字符、下划线）"""
+        request = UserUpdateRequest(username="user_name-123")
+        assert request.username == "user_name-123"
+
+    def test_username_with_numbers(self):
+        """测试 username 仅包含数字"""
+        request = UserUpdateRequest(username="123456")
+        assert request.username == "123456"
+
+    def test_username_case_sensitivity(self):
+        """测试 username 大小写敏感"""
+        request = UserUpdateRequest(username="UserName")
+        assert request.username == "UserName"
+        assert request.username != "username"
+
+    def test_email_case_insensitive_storage(self):
+        """测试 email 存储会将域名部分标准化为小写（Pydantic EmailStr 行为）"""
+        request = UserUpdateRequest(email="Test@Example.COM")
+        # Pydantic EmailStr 会将域名部分标准化为小写
+        assert request.email == "Test@example.com"
+
+    def test_unicode_in_username(self):
+        """测试 username 支持 unicode 字符"""
+        request = UserUpdateRequest(username="用户名")
+        assert request.username == "用户名"
+
+    def test_unicode_in_email_local_part(self):
+        """测试 email 本地部分支持 unicode 字符"""
+        # 注意：某些邮箱系统可能不支持 unicode，但 Pydantic 允许
+        request = UserUpdateRequest(email="测试@example.com")
+        assert request.email == "测试@example.com"

--- a/tests/backend/test_user_update_api.py
+++ b/tests/backend/test_user_update_api.py
@@ -1,0 +1,452 @@
+"""用户资料更新 API 端点单元测试
+
+测试范围：
+- 正常场景：更新用户名、更新邮箱、同时更新
+- 异常场景：邮箱冲突、用户名冲突、无效数据、未认证请求
+- Schema 验证测试
+
+契约来源：Issue #170 - src/backend/app/api/v1/auth.py 中的 update_current_user 端点
+"""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.backend.app.api.v1.auth import update_current_user
+from src.backend.app.models.user import User
+from src.backend.app.schemas.auth import UserUpdateRequest
+
+
+class TestUpdateCurrentUserSuccess:
+    """测试用户资料更新成功场景"""
+
+    @pytest.mark.asyncio
+    async def test_update_username_only(
+        self, mock_db_session, mock_user_repo, mock_current_user
+    ):
+        """测试仅更新用户名成功"""
+        # 准备请求数据
+        request = UserUpdateRequest(username="new_username")
+
+        # 配置 mock：用户名不存在（可以更新）
+        mock_user_repo.username_exists = AsyncMock(return_value=False)
+
+        # 执行更新
+        result = await update_current_user(
+            request=request,
+            current_user=mock_current_user,
+            user_repo=mock_user_repo,
+            session=mock_db_session,
+        )
+
+        # 验证结果
+        assert result.username == "new_username"
+        assert result.email == mock_current_user.email
+
+        # 验证数据库操作
+        mock_user_repo.username_exists.assert_called_once_with("new_username")
+        mock_user_repo.email_exists.assert_not_called()
+        mock_db_session.commit.assert_called_once()
+        mock_db_session.refresh.assert_called_once_with(mock_current_user)
+
+    @pytest.mark.asyncio
+    async def test_update_email_only(
+        self, mock_db_session, mock_user_repo, mock_current_user
+    ):
+        """测试仅更新邮箱成功"""
+        # 准备请求数据
+        request = UserUpdateRequest(email="new@example.com")
+
+        # 配置 mock：邮箱不存在（可以更新）
+        mock_user_repo.email_exists = AsyncMock(return_value=False)
+
+        # 执行更新
+        result = await update_current_user(
+            request=request,
+            current_user=mock_current_user,
+            user_repo=mock_user_repo,
+            session=mock_db_session,
+        )
+
+        # 验证结果
+        assert result.email == "new@example.com"
+        assert result.username == mock_current_user.username
+
+        # 验证数据库操作
+        mock_user_repo.email_exists.assert_called_once_with("new@example.com")
+        mock_user_repo.username_exists.assert_not_called()
+        mock_db_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_both_fields(
+        self, mock_db_session, mock_user_repo, mock_current_user
+    ):
+        """测试同时更新用户名和邮箱成功"""
+        # 准备请求数据
+        request = UserUpdateRequest(username="new_username", email="new@example.com")
+
+        # 配置 mock：用户名和邮箱均不存在
+        mock_user_repo.username_exists = AsyncMock(return_value=False)
+        mock_user_repo.email_exists = AsyncMock(return_value=False)
+
+        # 执行更新
+        result = await update_current_user(
+            request=request,
+            current_user=mock_current_user,
+            user_repo=mock_user_repo,
+            session=mock_db_session,
+        )
+
+        # 验证结果
+        assert result.username == "new_username"
+        assert result.email == "new@example.com"
+
+        # 验证数据库操作
+        mock_user_repo.username_exists.assert_called_once_with("new_username")
+        mock_user_repo.email_exists.assert_called_once_with("new@example.com")
+        mock_db_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_same_username_no_conflict_check(
+        self, mock_db_session, mock_user_repo, mock_current_user
+    ):
+        """测试更新为相同用户名时不检查冲突"""
+        # 设置当前用户名
+        mock_current_user.username = "existing_username"
+
+        # 准备请求数据（更新为相同的用户名）
+        request = UserUpdateRequest(username="existing_username")
+
+        # 执行更新
+        await update_current_user(
+            request=request,
+            current_user=mock_current_user,
+            user_repo=mock_user_repo,
+            session=mock_db_session,
+        )
+
+        # 验证不检查用户名冲突
+        mock_user_repo.username_exists.assert_not_called()
+        # 验证没有修改用户名
+        assert mock_current_user.username == "existing_username"
+
+    @pytest.mark.asyncio
+    async def test_update_same_email_no_conflict_check(
+        self, mock_db_session, mock_user_repo, mock_current_user
+    ):
+        """测试更新为相同邮箱时不检查冲突"""
+        # 设置当前邮箱
+        mock_current_user.email = "existing@example.com"
+
+        # 准备请求数据（更新为相同的邮箱）
+        request = UserUpdateRequest(email="existing@example.com")
+
+        # 执行更新
+        await update_current_user(
+            request=request,
+            current_user=mock_current_user,
+            user_repo=mock_user_repo,
+            session=mock_db_session,
+        )
+
+        # 验证不检查邮箱冲突
+        mock_user_repo.email_exists.assert_not_called()
+        # 验证没有修改邮箱
+        assert mock_current_user.email == "existing@example.com"
+
+
+class TestUpdateCurrentUserConflict:
+    """测试用户资料更新冲突场景"""
+
+    @pytest.mark.asyncio
+    async def test_username_already_exists(
+        self, mock_db_session, mock_user_repo, mock_current_user
+    ):
+        """测试用户名已存在时抛出 ConflictError"""
+        from src.backend.app.core.exceptions import ConflictError
+
+        # 准备请求数据
+        request = UserUpdateRequest(username="existing_user")
+
+        # 配置 mock：用户名已存在
+        mock_user_repo.username_exists = AsyncMock(return_value=True)
+
+        # 执行更新并验证异常
+        with pytest.raises(ConflictError) as exc_info:
+            await update_current_user(
+                request=request,
+                current_user=mock_current_user,
+                user_repo=mock_user_repo,
+                session=mock_db_session,
+            )
+
+        # 验证异常信息
+        assert "Username already exists" in str(exc_info.value)
+        assert exc_info.value.extra == {"field": "username"}
+
+        # 验证没有提交数据库
+        mock_db_session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_email_already_exists(
+        self, mock_db_session, mock_user_repo, mock_current_user
+    ):
+        """测试邮箱已存在时抛出 ConflictError"""
+        from src.backend.app.core.exceptions import ConflictError
+
+        # 准备请求数据
+        request = UserUpdateRequest(email="existing@example.com")
+
+        # 配置 mock：邮箱已存在
+        mock_user_repo.email_exists = AsyncMock(return_value=True)
+
+        # 执行更新并验证异常
+        with pytest.raises(ConflictError) as exc_info:
+            await update_current_user(
+                request=request,
+                current_user=mock_current_user,
+                user_repo=mock_user_repo,
+                session=mock_db_session,
+            )
+
+        # 验证异常信息
+        assert "Email already exists" in str(exc_info.value)
+        assert exc_info.value.extra == {"field": "email"}
+
+        # 验证没有提交数据库
+        mock_db_session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_username_conflict_before_email_check(
+        self, mock_db_session, mock_user_repo, mock_current_user
+    ):
+        """测试用户名冲突时不检查邮箱（短路逻辑）"""
+        from src.backend.app.core.exceptions import ConflictError
+
+        # 准备请求数据（同时更新用户名和邮箱）
+        request = UserUpdateRequest(username="existing_user", email="new@example.com")
+
+        # 配置 mock：用户名已存在
+        mock_user_repo.username_exists = AsyncMock(return_value=True)
+        mock_user_repo.email_exists = AsyncMock(return_value=False)
+
+        # 执行更新并验证异常
+        with pytest.raises(ConflictError):
+            await update_current_user(
+                request=request,
+                current_user=mock_current_user,
+                user_repo=mock_user_repo,
+                session=mock_db_session,
+            )
+
+        # 验证用户名检查被调用
+        mock_user_repo.username_exists.assert_called_once()
+        # 验证邮箱检查也被调用（因为代码会先检查用户名，然后继续检查邮箱）
+        # 实际上，根据实现，用户名冲突会立即抛出异常，不会检查邮箱
+        # 但这里的测试取决于具体实现顺序
+
+
+class TestUpdateCurrentUserValidation:
+    """测试用户资料更新验证场景"""
+
+    @pytest.mark.asyncio
+    async def test_invalid_username_too_short(
+        self, mock_db_session, mock_user_repo, mock_current_user
+    ):
+        """测试用户名太短时抛出 ValidationError"""
+        from pydantic import ValidationError
+
+        # 尝试创建无效请求
+        with pytest.raises(ValidationError):
+            UserUpdateRequest(username="ab")  # 小于 3 个字符
+
+    @pytest.mark.asyncio
+    async def test_invalid_username_too_long(
+        self, mock_db_session, mock_user_repo, mock_current_user
+    ):
+        """测试用户名太长时抛出 ValidationError"""
+        from pydantic import ValidationError
+
+        # 尝试创建无效请求
+        with pytest.raises(ValidationError):
+            UserUpdateRequest(username="a" * 51)  # 超过 50 个字符
+
+    @pytest.mark.asyncio
+    async def test_invalid_email_format(
+        self, mock_db_session, mock_user_repo, mock_current_user
+    ):
+        """测试邮箱格式无效时抛出 ValidationError"""
+        from pydantic import ValidationError
+
+        # 尝试创建无效请求
+        with pytest.raises(ValidationError):
+            UserUpdateRequest(email="invalid-email")
+
+    @pytest.mark.asyncio
+    async def test_no_fields_provided(
+        self, mock_db_session, mock_user_repo, mock_current_user
+    ):
+        """测试未提供任何更新字段时抛出 ValidationError"""
+        from pydantic import ValidationError
+
+        # 尝试创建无效请求
+        with pytest.raises(ValidationError):
+            UserUpdateRequest()
+
+
+class TestUpdateCurrentUserUnauthenticated:
+    """测试未认证场景"""
+
+    @pytest.mark.asyncio
+    async def test_no_current_user_raises_attribute_error(
+        self, mock_db_session, mock_user_repo
+    ):
+        """测试没有当前用户时抛出 AttributeError"""
+        # 准备请求数据
+        request = UserUpdateRequest(username="new_username")
+
+        # 执行更新并验证异常（没有 current_user 会抛出 AttributeError）
+        with pytest.raises(AttributeError):
+            await update_current_user(
+                request=request,
+                current_user=None,
+                user_repo=mock_user_repo,
+                session=mock_db_session,
+            )
+
+
+class TestUpdateCurrentUserEdgeCases:
+    """测试用户资料更新边界情况"""
+
+    @pytest.mark.asyncio
+    async def test_case_sensitive_username_check(
+        self, mock_db_session, mock_user_repo, mock_current_user
+    ):
+        """测试用户名大小写敏感检查"""
+        # 设置当前用户名
+        mock_current_user.username = "TestUser"
+
+        # 准备请求数据（不同大小写）
+        request = UserUpdateRequest(username="testuser")
+
+        # 配置 mock：用户名已存在
+        mock_user_repo.username_exists = AsyncMock(return_value=True)
+
+        # 执行更新会抛出冲突异常
+        from src.backend.app.core.exceptions import ConflictError
+
+        with pytest.raises(ConflictError):
+            await update_current_user(
+                request=request,
+                current_user=mock_current_user,
+                user_repo=mock_user_repo,
+                session=mock_db_session,
+            )
+
+    @pytest.mark.asyncio
+    async def test_email_case_insensitive_check(
+        self, mock_db_session, mock_user_repo, mock_current_user
+    ):
+        """测试邮箱大小写不敏感检查"""
+        # 设置当前邮箱
+        mock_current_user.email = "test@example.com"
+
+        # 准备请求数据（不同大小写）
+        request = UserUpdateRequest(email="TEST@EXAMPLE.COM")
+
+        # 配置 mock：邮箱已存在（大小写不敏感）
+        mock_user_repo.email_exists = AsyncMock(return_value=True)
+
+        # 执行更新会抛出冲突异常
+        from src.backend.app.core.exceptions import ConflictError
+
+        with pytest.raises(ConflictError):
+            await update_current_user(
+                request=request,
+                current_user=mock_current_user,
+                user_repo=mock_user_repo,
+                session=mock_db_session,
+            )
+
+    @pytest.mark.asyncio
+    async def test_unicode_username(
+        self, mock_db_session, mock_user_repo, mock_current_user
+    ):
+        """测试支持 unicode 用户名"""
+        # 准备请求数据
+        request = UserUpdateRequest(username="用户名")
+
+        # 配置 mock：用户名不存在
+        mock_user_repo.username_exists = AsyncMock(return_value=False)
+
+        # 执行更新
+        result = await update_current_user(
+            request=request,
+            current_user=mock_current_user,
+            user_repo=mock_user_repo,
+            session=mock_db_session,
+        )
+
+        # 验证结果
+        assert result.username == "用户名"
+
+    @pytest.mark.asyncio
+    async def test_refresh_token_format(
+        self, mock_db_session, mock_user_repo, mock_current_user
+    ):
+        """测试邮箱格式验证"""
+        # 准备各种有效邮箱格式
+        valid_emails = [
+            "test@example.com",
+            "user.name@domain.co.uk",
+            "user+tag@test.com",
+        ]
+
+        for email in valid_emails:
+            request = UserUpdateRequest(email=email)
+            mock_user_repo.email_exists = AsyncMock(return_value=False)
+
+            result = await update_current_user(
+                request=request,
+                current_user=mock_current_user,
+                user_repo=mock_user_repo,
+                session=mock_db_session,
+            )
+
+            assert result.email == email
+
+
+# ==================== Fixtures ====================
+
+
+@pytest.fixture
+def mock_db_session():
+    """模拟数据库会话"""
+    session = Mock(spec=AsyncSession)
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def mock_user_repo():
+    """模拟用户仓储"""
+    repo = Mock()
+    repo.username_exists = AsyncMock(return_value=False)
+    repo.email_exists = AsyncMock(return_value=False)
+    return repo
+
+
+@pytest.fixture
+def mock_current_user():
+    """模拟当前用户"""
+    from datetime import datetime
+
+    user = Mock(spec=User)
+    user.id = 1
+    user.username = "testuser"
+    user.email = "test@example.com"
+    user.is_active = True
+    user.created_at = datetime(2024, 1, 1, 0, 0, 0)
+    return user


### PR DESCRIPTION
## Summary

- 添加 `PATCH /api/v1/auth/me` 端点支持用户名和邮箱更新
- 创建 `UserUpdateRequest` Schema 进行请求验证
- 实现用户名/邮箱唯一性冲突检测
- 编写完整的单元测试覆盖正常和异常场景（39 个测试用例）
- 修复现有代码中的 mypy 类型注解问题

## Test Plan

- [x] 单元测试：更新用户名、更新邮箱、同时更新
- [x] 异常测试：用户名冲突、邮箱冲突、无效数据
- [x] Schema 验证测试：边界值、格式校验、序列化
- [x] 所有 1124 个单元测试通过

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)