### PR TITLE
feat: 实现用户资料页面功能 (Issue #171)

### DIFF
--- a/docs/blueprints/profile-page-blueprint.md
+++ b/docs/blueprints/profile-page-blueprint.md
@@ -1,0 +1,935 @@
+# 用户资料页面开发蓝图
+
+**Issue**: #171 (父 Issue)
+**子任务**:
+- #173: 前端 API 扩展
+- #174: UI 组件开发
+- #175: 页面集成与测试
+
+**架构师**: task-architect
+**日期**: 2026-03-11
+
+---
+
+## 1. 架构概览
+
+### 1.1 文件结构
+
+```
+frontend/src/
+├── types/
+│   └── auth.ts                    # [修改] 添加 UserUpdateRequest/Response
+├── lib/
+│   ├── api/
+│   │   └── auth-api.ts            # [修改] 添加 updateProfile() 方法
+│   └── validation/
+│       └── profile-validation.ts  # [新建] 用户资料验证规则
+├── components/
+│   └── profile/
+│       ├── UserInfoCard.tsx       # [新建] 用户信息展示卡片
+│       ├── ProfileForm.tsx        # [新建] 资料编辑表单
+│       └── index.ts               # [新建] 导出文件
+└── app/
+    └── profile/
+        └── page.tsx               # [新建] 用户资料页面
+```
+
+### 1.2 数据流
+
+```
+[ProfilePage]
+    │
+    ├── 加载阶段 ──► [authApi.getCurrentUser()] ──► [authStore.user]
+    │                                                   │
+    │                                                   ▼
+    │                                           [UserInfoCard] (展示)
+    │
+    └── 编辑阶段 ──► [ProfileForm]
+                          │
+                          ├── 验证 ──► [ProfileValidator]
+                          │
+                          └── 提交 ──► [authApi.updateProfile()]
+                                            │
+                                            ▼
+                                      [authStore.user] (更新)
+```
+
+---
+
+## 2. 类型定义 (TypeScript Interfaces)
+
+### 2.1 请求/响应模型
+
+**文件**: `frontend/src/types/auth.ts`
+
+```typescript
+// ============================================================================
+// 用户资料更新相关类型 (新增)
+// ============================================================================
+
+/**
+ * 用户资料更新请求模型
+ * 对应后端 UserUpdateRequest schema
+ */
+export interface UserUpdateRequest {
+  /** 用户名 (可选, 3-50 字符) */
+  username?: string;
+  /** 邮箱地址 (可选) */
+  email?: string;
+}
+
+/**
+ * 用户资料更新响应模型
+ * 对应后端 UserResponse schema (与 getCurrentUser 返回类型一致)
+ */
+export type UserUpdateResponse = UserResponse;
+
+/**
+ * 用户资料表单数据
+ * 用于 ProfileForm 组件内部状态管理
+ */
+export interface ProfileFormData {
+  /** 用户名 */
+  username: string;
+  /** 邮箱地址 */
+  email: string;
+}
+
+/**
+ * 用户资料表单错误
+ */
+export interface ProfileFormErrors {
+  /** 用户名错误 */
+  username?: string;
+  /** 邮箱错误 */
+  email?: string;
+}
+```
+
+### 2.2 API 错误类型扩展
+
+```typescript
+/**
+ * API 错误响应类型 (扩展现有定义)
+ */
+export interface ApiErrorResponse {
+  /** 错误详情 */
+  detail: string;
+  /** 冲突字段 (用于 409 错误) */
+  field?: 'username' | 'email';
+}
+
+/**
+ * 用户资料更新错误类型枚举
+ */
+export enum ProfileUpdateErrorType {
+  /** 用户名已存在 */
+  USERNAME_EXISTS = 'USERNAME_EXISTS',
+  /** 邮箱已存在 */
+  EMAIL_EXISTS = 'EMAIL_EXISTS',
+  /** 网络错误 */
+  NETWORK_ERROR = 'NETWORK_ERROR',
+  /** 验证错误 */
+  VALIDATION_ERROR = 'VALIDATION_ERROR',
+  /** 未认证 */
+  UNAUTHORIZED = 'UNAUTHORIZED',
+  /** 未知错误 */
+  UNKNOWN_ERROR = 'UNKNOWN_ERROR',
+}
+```
+
+---
+
+## 3. API 层设计
+
+### 3.1 AuthApi 扩展
+
+**文件**: `frontend/src/lib/api/auth-api.ts`
+
+```typescript
+// ============================================================================
+// 新增方法 (添加到现有 AuthApi 类中)
+// ============================================================================
+
+/**
+ * 更新当前用户资料
+ *
+ * 对应后端：PATCH /api/v1/auth/me
+ *
+ * @param data - 更新数据 (username 和/或 email)
+ * @returns 更新后的用户信息
+ * @throws {Error} 更新失败时抛出异常
+ *
+ * @example
+ * ```ts
+ * // 仅更新用户名
+ * const user = await authApi.updateProfile({ username: 'newname' });
+ *
+ * // 同时更新用户名和邮箱
+ * const user = await authApi.updateProfile({
+ *   username: 'newname',
+ *   email: 'new@email.com'
+ * });
+ * ```
+ */
+async updateProfile(data: UserUpdateRequest): Promise<UserUpdateResponse> {
+  // 实现待补充 (task-developer)
+  // 步骤 1: 调用 this.httpClient.patch<UserUpdateResponse>('/api/v1/auth/me', data)
+  // 步骤 2: 更新 authStore.user (可选, 通过外部回调或 store 方法)
+  // 步骤 3: 返回更新后的用户信息
+  throw new Error('Not implemented');
+}
+```
+
+### 3.2 错误处理策略
+
+```typescript
+/**
+ * 用户资料更新错误处理映射
+ */
+const PROFILE_UPDATE_ERROR_MESSAGES: Record<string, string> = {
+  USERNAME_EXISTS: '该用户名已被使用',
+  EMAIL_EXISTS: '该邮箱已被注册',
+  NETWORK_ERROR: '网络连接失败，请稍后重试',
+  VALIDATION_ERROR: '输入信息格式不正确',
+  UNAUTHORIZED: '请先登录后再试',
+  UNKNOWN_ERROR: '更新失败，请稍后重试',
+};
+
+/**
+ * 解析 API 错误响应
+ *
+ * @param error - 捕获的错误对象
+ * @returns 用户友好的错误消息
+ */
+function parseUpdateError(error: unknown): string {
+  // 实现待补充 (task-developer)
+  // 解析 409 Conflict 错误的 field 字段
+  // 解析 400 Validation 错误
+  // 返回对应的中文错误消息
+  throw new Error('Not implemented');
+}
+```
+
+---
+
+## 4. 验证层设计
+
+### 4.1 ProfileValidator 类
+
+**文件**: `frontend/src/lib/validation/profile-validation.ts`
+
+```typescript
+/**
+ * 用户资料验证规则
+ *
+ * 职责:
+ * - 定义用户名、邮箱的验证规则
+ * - 提供字段级验证方法
+ * - 与后端 Pydantic 验证规则保持一致
+ *
+ * @module frontend/src/lib/validation/profile-validation
+ */
+
+// ============================================================================
+// 类型定义
+// ============================================================================
+
+/**
+ * 字段验证结果
+ */
+export interface FieldValidationResult {
+  /** 是否有效 */
+  isValid: boolean;
+  /** 错误消息 (无效时存在) */
+  error?: string;
+}
+
+/**
+ * 用户资料表单验证结果
+ */
+export interface ProfileFormValidation {
+  /** 用户名验证结果 */
+  username: FieldValidationResult;
+  /** 邮箱验证结果 */
+  email: FieldValidationResult;
+  /** 整体表单是否有效 */
+  isValid: boolean;
+}
+
+// ============================================================================
+// 常量定义
+// ============================================================================
+
+/**
+ * 验证规则常量
+ */
+const VALIDATION_RULES = {
+  /** 用户名最小长度 */
+  USERNAME_MIN_LENGTH: 3,
+  /** 用户名最大长度 */
+  USERNAME_MAX_LENGTH: 50,
+} as const;
+
+/**
+ * 错误消息常量
+ */
+const ERROR_MESSAGES = {
+  USERNAME_REQUIRED: '用户名不能为空',
+  USERNAME_LENGTH: '用户名长度应为 3-50 个字符',
+  USERNAME_FORMAT: '用户名格式不正确，只能包含字母、数字、下划线和连字符',
+  EMAIL_REQUIRED: '邮箱不能为空',
+  EMAIL_INVALID: '邮箱格式不正确',
+} as const;
+
+/**
+ * 用户名正则表达式
+ * 与后端验证规则保持一致
+ */
+const USERNAME_REGEX = /^[a-zA-Z0-9_-]+$/;
+
+/**
+ * 邮箱正则表达式
+ */
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// ============================================================================
+// 验证器类
+// ============================================================================
+
+/**
+ * 用户资料验证器
+ *
+ * 提供静态方法验证用户资料表单的各个字段
+ */
+export class ProfileValidator {
+  /**
+   * 验证用户名
+   *
+   * 规则:
+   * - 必填
+   * - 3-50 字符
+   * - 仅允许字母、数字、下划线、连字符
+   *
+   * @param username - 用户名
+   * @returns 验证结果
+   */
+  static validateUsername(username: string): FieldValidationResult {
+    // 实现待补充 (task-developer)
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * 验证邮箱
+   *
+   * 规则:
+   * - 必填
+   * - 标准邮箱格式
+   *
+   * @param email - 邮箱地址
+   * @returns 验证结果
+   */
+  static validateEmail(email: string): FieldValidationResult {
+    // 实现待补充 (task-developer)
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * 验证整个表单
+   *
+   * @param data - 表单数据
+   * @returns 表单验证结果
+   */
+  static validateForm(data: ProfileFormData): ProfileFormValidation {
+    // 实现待补充 (task-developer)
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * 检查表单数据是否有变更
+   *
+   * @param original - 原始数据
+   * @param current - 当前数据
+   * @returns 是否有变更
+   */
+  static hasChanges(
+    original: ProfileFormData,
+    current: ProfileFormData
+  ): boolean {
+    return original.username !== current.username || original.email !== current.email;
+  }
+}
+```
+
+---
+
+## 5. 组件设计
+
+### 5.1 UserInfoCard 组件
+
+**文件**: `frontend/src/components/profile/UserInfoCard.tsx`
+
+```typescript
+/**
+ * 用户信息展示卡片组件
+ *
+ * 功能:
+ * - 展示用户基本信息 (用户名、邮箱、注册时间)
+ * - 提供编辑按钮切换到编辑模式
+ * - 支持加载状态和骨架屏
+ *
+ * @module frontend/src/components/profile/UserInfoCard
+ */
+
+import type { UserResponse } from '@/types/auth';
+import { Card } from '@/components/ui';
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// 类型定义
+// ============================================================================
+
+/**
+ * UserInfoCard Props
+ */
+export interface UserInfoCardProps {
+  /** 用户信息 */
+  user: UserResponse;
+  /** 是否处于编辑模式 */
+  isEditing?: boolean;
+  /** 编辑按钮点击回调 */
+  onEditClick?: () => void;
+  /** 自定义类名 */
+  className?: string;
+}
+
+// ============================================================================
+// 组件实现
+// ============================================================================
+
+/**
+ * 用户信息展示卡片
+ *
+ * @example
+ * ```tsx
+ * <UserInfoCard
+ *   user={authStore.user}
+ *   isEditing={false}
+ *   onEditClick={() => setIsEditing(true)}
+ * />
+ * ```
+ */
+export function UserInfoCard({
+  user,
+  isEditing = false,
+  onEditClick,
+  className,
+}: UserInfoCardProps): JSX.Element {
+  // 实现待补充 (task-developer)
+  // 渲染:
+  // - Card 容器
+  // - 用户头像 (可选, 使用首字母占位)
+  // - 用户名
+  // - 邮箱
+  // - 注册时间 (格式化显示)
+  // - 编辑按钮 (非编辑模式时显示)
+  throw new Error('Not implemented');
+}
+```
+
+### 5.2 ProfileForm 组件
+
+**文件**: `frontend/src/components/profile/ProfileForm.tsx`
+
+```typescript
+/**
+ * 用户资料编辑表单组件
+ *
+ * 功能:
+ * - 渲染用户名和邮箱输入框
+ * - 实时表单验证
+ * - 提交处理
+ * - 加载状态显示
+ * - 错误提示
+ * - 取消编辑恢复原始数据
+ *
+ * @module frontend/src/components/profile/ProfileForm
+ */
+
+import { useState, useCallback, useEffect } from 'react';
+import type { FormEvent } from 'react';
+import { Button, Input, Alert, Spinner } from '@/components/ui';
+import { ProfileValidator } from '@/lib/validation/profile-validation';
+import type {
+  UserResponse,
+  UserUpdateRequest,
+  ProfileFormData,
+  ProfileFormErrors,
+} from '@/types/auth';
+import type { AuthApi } from '@/lib/api/auth-api';
+import type { AuthStore } from '@/store/auth/auth-store-types';
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// 类型定义
+// ============================================================================
+
+/**
+ * 触碰状态 (字段是否被用户交互过)
+ */
+interface TouchedState {
+  username: boolean;
+  email: boolean;
+}
+
+/**
+ * ProfileForm Props
+ */
+export interface ProfileFormProps {
+  /** 当前用户信息 (用于初始化表单) */
+  user: UserResponse;
+  /** AuthApi 实例 (可选, 用于测试) */
+  authApi?: AuthApi;
+  /** AuthStore 实例 (可选, 用于测试) */
+  authStore?: AuthStore;
+  /** 更新成功回调 */
+  onSuccess?: (user: UserResponse) => void;
+  /** 更新失败回调 */
+  onError?: (error: Error) => void;
+  /** 取消编辑回调 */
+  onCancel?: () => void;
+  /** 自定义类名 */
+  className?: string;
+}
+
+// ============================================================================
+// 组件实现
+// ============================================================================
+
+/**
+ * 用户资料编辑表单
+ *
+ * @example
+ * ```tsx
+ * <ProfileForm
+ *   user={authStore.user}
+ *   onSuccess={(user) => {
+ *     console.log('更新成功:', user);
+ *     setIsEditing(false);
+ *   }}
+ *   onCancel={() => setIsEditing(false)}
+ * />
+ * ```
+ */
+export function ProfileForm({
+  user,
+  authApi: injectedAuthApi,
+  authStore: injectedAuthStore,
+  onSuccess,
+  onError,
+  onCancel,
+  className,
+}: ProfileFormProps): JSX.Element {
+  // ----------------------------------------------------------------------
+  // 状态管理
+  // ----------------------------------------------------------------------
+
+  /** 表单字段值 */
+  const [formData, setFormData] = useState<ProfileFormData>({
+    username: user.username,
+    email: user.email,
+  });
+
+  /** 原始数据 (用于取消时恢复) */
+  const [originalData] = useState<ProfileFormData>({
+    username: user.username,
+    email: user.email,
+  });
+
+  /** 字段级验证错误 */
+  const [fieldErrors, setFieldErrors] = useState<ProfileFormErrors>({});
+
+  /** 表单触碰状态 */
+  const [touched, setTouched] = useState<TouchedState>({
+    username: false,
+    email: false,
+  });
+
+  /** 提交状态 */
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  /** 提交级别的错误 */
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // ----------------------------------------------------------------------
+  // 验证逻辑
+  // ----------------------------------------------------------------------
+
+  /**
+   * 验证单个字段
+   */
+  const validateField = useCallback(
+    (field: keyof ProfileFormErrors, value: string) => {
+      // 实现待补充 (task-developer)
+      throw new Error('Not implemented');
+    },
+    []
+  );
+
+  /**
+   * 验证整个表单
+   */
+  const validateForm = useCallback((): boolean => {
+    // 实现待补充 (task-developer)
+    throw new Error('Not implemented');
+  }, [formData]);
+
+  // ----------------------------------------------------------------------
+  // 事件处理
+  // ----------------------------------------------------------------------
+
+  /**
+   * 字段变更处理
+   */
+  const handleFieldChange = (
+    field: keyof typeof touched,
+    value: string
+  ) => {
+    // 实现待补充 (task-developer)
+    throw new Error('Not implemented');
+  };
+
+  /**
+   * 字段失焦处理
+   */
+  const handleFieldBlur = (field: keyof typeof touched) => {
+    // 实现待补充 (task-developer)
+    throw new Error('Not implemented');
+  };
+
+  /**
+   * 表单提交处理
+   */
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    // 实现待补充 (task-developer)
+    // 步骤 1: 阻止默认提交
+    // 步骤 2: 清除提交错误
+    // 步骤 3: 标记所有字段为已触碰
+    // 步骤 4: 验证表单
+    // 步骤 5: 检查是否有变更 (ProfileValidator.hasChanges)
+    // 步骤 6: 调用 authApi.updateProfile()
+    // 步骤 7: 更新 authStore.user (可选)
+    // 步骤 8: 触发成功回调
+    throw new Error('Not implemented');
+  };
+
+  /**
+   * 取消编辑处理
+   */
+  const handleCancel = () => {
+    // 实现待补充 (task-developer)
+    // 恢复原始数据
+    // 清除错误
+    // 触发取消回调
+    throw new Error('Not implemented');
+  };
+
+  // ----------------------------------------------------------------------
+  // 渲染
+  // ----------------------------------------------------------------------
+
+  /** 计算是否有变更 */
+  const hasChanges = ProfileValidator.hasChanges(originalData, formData);
+
+  /** 计算表单是否有效 */
+  const isFormValid =
+    formData.username !== '' &&
+    formData.email !== '' &&
+    Object.keys(fieldErrors).length === 0 &&
+    hasChanges;
+
+  return (
+    <form
+      role="form"
+      aria-labelledby="profile-form-title"
+      onSubmit={handleSubmit}
+      noValidate
+      className={cn('profile-form', className)}
+    >
+      {/* 实现待补充 (task-developer) */}
+      {/* 用户名输入框 */}
+      {/* 邮箱输入框 */}
+      {/* 提交错误提示 */}
+      {/* 操作按钮 (保存/取消) */}
+      throw new Error('Not implemented');
+    </form>
+  );
+}
+```
+
+---
+
+## 6. 页面集成设计
+
+### 6.1 ProfilePage 页面
+
+**文件**: `frontend/src/app/profile/page.tsx`
+
+```typescript
+/**
+ * 用户资料页面
+ *
+ * 功能:
+ * - 使用 withAuthGuard HOC 保护路由
+ * - 展示用户信息卡片
+ * - 支持编辑模式切换
+ * - 数据加载状态处理
+ *
+ * @module frontend/src/app/profile/page
+ */
+
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/router';
+import { withAuthGuard } from '@/lib/auth/guards';
+import { authStore } from '@/store/auth/auth-store';
+import { authApi } from '@/lib/api/endpoints';
+import { UserInfoCard } from '@/components/profile/UserInfoCard';
+import { ProfileForm } from '@/components/profile/ProfileForm';
+import { Spinner } from '@/components/ui';
+import type { UserResponse } from '@/types/auth';
+
+// ============================================================================
+// 内部页面组件 (未保护)
+// ============================================================================
+
+/**
+ * 用户资料页面内部组件
+ */
+function ProfilePageInternal(): JSX.Element {
+  // ----------------------------------------------------------------------
+  // 状态管理
+  // ----------------------------------------------------------------------
+
+  const router = useRouter();
+  const [user, setUser] = useState<UserResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isEditing, setIsEditing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // ----------------------------------------------------------------------
+  // 数据加载
+  // ----------------------------------------------------------------------
+
+  /**
+   * 加载用户信息
+   */
+  const loadUser = useCallback(async () => {
+    // 实现待补充 (task-developer)
+    // 从 authStore 获取用户信息
+    // 如果 store 中没有, 调用 authApi.getCurrentUser()
+    // 更新本地状态
+    throw new Error('Not implemented');
+  }, []);
+
+  useEffect(() => {
+    loadUser();
+  }, [loadUser]);
+
+  // ----------------------------------------------------------------------
+  // 事件处理
+  // ----------------------------------------------------------------------
+
+  /**
+   * 更新成功处理
+   */
+  const handleUpdateSuccess = (updatedUser: UserResponse) => {
+    // 实现待补充 (task-developer)
+    // 更新本地状态
+    // 更新 authStore.user
+    // 退出编辑模式
+    throw new Error('Not implemented');
+  };
+
+  /**
+   * 更新失败处理
+   */
+  const handleUpdateError = (error: Error) => {
+    // 实现待补充 (task-developer)
+    // 设置错误状态
+    // 可选: 显示 Toast 提示
+    throw new Error('Not implemented');
+  };
+
+  // ----------------------------------------------------------------------
+  // 渲染
+  // ----------------------------------------------------------------------
+
+  // 加载状态
+  if (isLoading) {
+    return (
+      <div className="profile-page-loading">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  // 错误状态
+  if (error) {
+    return (
+      <div className="profile-page-error">
+        <p>{error}</p>
+        <button onClick={loadUser}>重试</button>
+      </div>
+    );
+  }
+
+  // 无用户数据
+  if (!user) {
+    return (
+      <div className="profile-page-empty">
+        <p>无法加载用户信息</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="profile-page">
+      <h1 className="profile-page-title">个人资料</h1>
+
+      {isEditing ? (
+        <ProfileForm
+          user={user}
+          onSuccess={handleUpdateSuccess}
+          onError={handleUpdateError}
+          onCancel={() => setIsEditing(false)}
+        />
+      ) : (
+        <UserInfoCard
+          user={user}
+          isEditing={false}
+          onEditClick={() => setIsEditing(true)}
+        />
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// 导出 (使用 withAuthGuard 保护)
+// ============================================================================
+
+/**
+ * 用户资料页面 (已保护)
+ */
+const ProfilePage = withAuthGuard(ProfilePageInternal, {
+  redirectTo: '/login',
+  showLoading: true,
+});
+
+export default ProfilePage;
+```
+
+---
+
+## 7. 测试规划
+
+### 7.1 单元测试范围
+
+| 模块 | 测试文件 | 测试重点 |
+|------|----------|----------|
+| ProfileValidator | `profile-validation.test.ts` | 验证规则、边界条件、错误消息 |
+| ProfileForm | `ProfileForm.test.tsx` | 表单交互、验证、提交、错误处理 |
+| UserInfoCard | `UserInfoCard.test.tsx` | 数据展示、编辑按钮交互 |
+| AuthApi.updateProfile | `auth-api.test.ts` (扩展) | API 调用、错误处理、Token 更新 |
+
+### 7.2 集成测试范围
+
+- 页面加载流程: 未登录重定向、数据加载
+- 编辑流程: 切换编辑模式、表单验证、提交成功/失败
+- 数据同步: authStore 状态更新、页面状态同步
+
+### 7.3 E2E 测试场景
+
+- 完整资料更新流程
+- 冲突错误处理 (用户名/邮箱已存在)
+- 网络错误恢复
+
+---
+
+## 8. 依赖关系
+
+```
+#173 (API 扩展)
+    │
+    ├──► 无前置依赖
+    │
+    └──► 被 #174 依赖
+
+#174 (UI 组件)
+    │
+    ├──► 依赖 #173 (API 扩展)
+    │
+    └──► 被 #175 依赖
+
+#175 (页面集成)
+    │
+    ├──► 依赖 #174 (UI 组件)
+    │
+    └──► 无后续依赖
+```
+
+---
+
+## 9. 技术规范
+
+### 9.1 命名约定
+
+- 组件: PascalCase (如 `ProfileForm`)
+- 文件: kebab-case (如 `profile-validation.ts`)
+- 类型/接口: PascalCase (如 `UserUpdateRequest`)
+- 常量: UPPER_SNAKE_CASE (如 `USERNAME_MIN_LENGTH`)
+
+### 9.2 代码风格
+
+- 使用 TypeScript 严格模式
+- 遵循现有项目的 ESLint 配置
+- 组件使用函数式组件 + Hooks
+- 状态管理使用 Zustand (与现有架构一致)
+
+### 9.3 验证规则对齐
+
+| 字段 | 前端规则 | 后端规则 | 状态 |
+|------|----------|----------|------|
+| username | 3-50字符, 字母数字下划线连字符 | 3-50字符, 同左 | 一致 |
+| email | 标准邮箱格式 | EmailStr | 一致 |
+
+---
+
+## 10. 附录: 完整类型导出
+
+```typescript
+// types/auth.ts (新增导出)
+export type { UserUpdateRequest, UserUpdateResponse, ProfileFormData, ProfileFormErrors };
+export { ProfileUpdateErrorType };
+```
+
+```typescript
+// lib/api/auth-api.ts (新增方法签名)
+export interface AuthApi {
+  login(usernameOrEmail: string, password: string): Promise<LoginResponse>;
+  register(username: string, email: string, password: string): Promise<RegisterResponse>;
+  refreshToken(): Promise<TokenResponse>;
+  getCurrentUser(): Promise<UserResponse>;
+  updateProfile(data: UserUpdateRequest): Promise<UserUpdateResponse>; // 新增
+}
+```
+
+```typescript
+// components/profile/index.ts (导出文件)
+export { UserInfoCard } from './UserInfoCard';
+export type { UserInfoCardProps } from './UserInfoCard';
+export { ProfileForm } from './ProfileForm';
+export type { ProfileFormProps } from './ProfileForm';
+```

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -1,0 +1,175 @@
+/**
+ * 用户资料页面
+ *
+ * 路由: /profile
+ *
+ * 功能:
+ * - 使用 withAuthGuard HOC 保护路由
+ * - 展示用户信息卡片
+ * - 支持编辑模式切换
+ * - 数据加载状态处理
+ *
+ * @module frontend/src/app/profile/page
+ */
+
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { withAuthGuard } from '@/lib/auth/guards';
+import { authStore } from '@/store/auth/auth-store';
+import { authApi } from '@/lib/api/endpoints';
+import { UserInfoCard, ProfileForm } from '@/components/profile';
+import { Spinner } from '@/components/ui';
+import type { UserResponse } from '@/types/auth';
+
+// ============================================================================
+// 内部页面组件 (未保护)
+// ============================================================================
+
+/**
+ * 用户资料页面内部组件
+ */
+function ProfilePageInternal(): JSX.Element {
+  // ----------------------------------------------------------------------
+  // 状态管理
+  // ----------------------------------------------------------------------
+
+  const [user, setUser] = useState<UserResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isEditing, setIsEditing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // ----------------------------------------------------------------------
+  // 数据加载
+  // ----------------------------------------------------------------------
+
+  /**
+   * 加载用户信息
+   */
+  const loadUser = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      // 从 authStore 获取用户信息
+      const state = authStore.getState();
+      let currentUser = state.user;
+
+      // 如果 store 中没有用户信息，调用 API 获取
+      if (!currentUser) {
+        currentUser = await authApi.getCurrentUser();
+      }
+
+      setUser(currentUser);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : '加载用户信息失败';
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadUser();
+  }, [loadUser]);
+
+  // ----------------------------------------------------------------------
+  // 事件处理
+  // ----------------------------------------------------------------------
+
+  /**
+   * 更新成功处理
+   */
+  const handleUpdateSuccess = (updatedUser: UserResponse) => {
+    // 更新本地状态
+    setUser(updatedUser);
+    // 退出编辑模式
+    setIsEditing(false);
+  };
+
+  /**
+   * 更新失败处理
+   */
+  const handleUpdateError = (err: Error) => {
+    // 错误已在 ProfileForm 组件中处理并显示
+    // 这里可以添加额外的错误追踪或日志
+    console.error('更新资料失败:', err);
+  };
+
+  // ----------------------------------------------------------------------
+  // 渲染
+  // ----------------------------------------------------------------------
+
+  // 加载状态
+  if (isLoading) {
+    return (
+      <div className="profile-page-loading min-h-screen flex items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  // 错误状态
+  if (error) {
+    return (
+      <div className="profile-page-error min-h-screen flex flex-col items-center justify-center px-4">
+        <p className="text-red-600 mb-4">{error}</p>
+        <button
+          type="button"
+          onClick={loadUser}
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          重试
+        </button>
+      </div>
+    );
+  }
+
+  // 无用户数据
+  if (!user) {
+    return (
+      <div className="profile-page-empty min-h-screen flex items-center justify-center">
+        <p className="text-gray-600">无法加载用户信息</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="profile-page min-h-screen bg-gray-50 px-4 py-12">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="profile-page-title text-2xl font-bold text-gray-900 mb-8">
+          个人资料
+        </h1>
+
+        {isEditing ? (
+          <ProfileForm
+            user={user}
+            onSuccess={handleUpdateSuccess}
+            onError={handleUpdateError}
+            onCancel={() => setIsEditing(false)}
+          />
+        ) : (
+          <UserInfoCard
+            user={user}
+            isEditing={false}
+            onEditClick={() => setIsEditing(true)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// 导出 (使用 withAuthGuard 保护)
+// ============================================================================
+
+/**
+ * 用户资料页面 (已保护)
+ */
+const ProfilePage = withAuthGuard(ProfilePageInternal, {
+  redirectTo: '/login',
+  showLoading: true,
+});
+
+export default ProfilePage;

--- a/frontend/src/components/profile/ProfileForm.tsx
+++ b/frontend/src/components/profile/ProfileForm.tsx
@@ -1,0 +1,401 @@
+/**
+ * 用户资料编辑表单组件
+ *
+ * 功能:
+ * - 渲染用户名和邮箱输入框
+ * - 实时表单验证
+ * - 提交处理
+ * - 加载状态显示
+ * - 错误提示
+ * - 取消编辑恢复原始数据
+ *
+ * @module frontend/src/components/profile/ProfileForm
+ */
+
+import { useState, useCallback } from 'react';
+import type { FormEvent } from 'react';
+import { Button, Input, Alert } from '@/components/ui';
+import { ProfileValidator } from '@/lib/validation/profile-validation';
+import type {
+  UserResponse,
+  ProfileFormData,
+  ProfileFormErrors,
+} from '@/types/auth';
+import type { AuthApi } from '@/lib/api/auth-api';
+import type { AuthStore } from '@/store/auth/auth-store-types';
+import { authApi as defaultAuthApi } from '@/lib/api/endpoints';
+import { authStore as defaultAuthStore } from '@/store/auth/auth-store';
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// 类型定义
+// ============================================================================
+
+/**
+ * 触碰状态 (字段是否被用户交互过)
+ */
+interface TouchedState {
+  username: boolean;
+  email: boolean;
+}
+
+/**
+ * ProfileForm Props
+ */
+export interface ProfileFormProps {
+  /** 当前用户信息 (用于初始化表单) */
+  user: UserResponse;
+  /** AuthApi 实例 (可选, 用于测试) */
+  authApi?: AuthApi;
+  /** AuthStore 实例 (可选, 用于测试) */
+  authStore?: AuthStore;
+  /** 更新成功回调 */
+  onSuccess?: (user: UserResponse) => void;
+  /** 更新失败回调 */
+  onError?: (error: Error) => void;
+  /** 取消编辑回调 */
+  onCancel?: () => void;
+  /** 自定义类名 */
+  className?: string;
+}
+
+// ============================================================================
+// 组件实现
+// ============================================================================
+
+/**
+ * 用户资料编辑表单
+ *
+ * @example
+ * ```tsx
+ * <ProfileForm
+ *   user={authStore.user}
+ *   onSuccess={(user) => {
+ *     console.log('更新成功:', user);
+ *     setIsEditing(false);
+ *   }}
+ *   onCancel={() => setIsEditing(false)}
+ * />
+ * ```
+ */
+export function ProfileForm({
+  user,
+  authApi: injectedAuthApi,
+  authStore: injectedAuthStore,
+  onSuccess,
+  onError,
+  onCancel,
+  className,
+}: ProfileFormProps): JSX.Element {
+  // ----------------------------------------------------------------------
+  // 依赖注入
+  // ----------------------------------------------------------------------
+  const authApi = injectedAuthApi ?? defaultAuthApi;
+  const store = injectedAuthStore ?? defaultAuthStore;
+
+  // ----------------------------------------------------------------------
+  // 状态管理
+  // ----------------------------------------------------------------------
+
+  /** 表单字段值 */
+  const [formData, setFormData] = useState<ProfileFormData>({
+    username: user.username,
+    email: user.email,
+  });
+
+  /** 原始数据 (用于取消时恢复) */
+  const [originalData] = useState<ProfileFormData>({
+    username: user.username,
+    email: user.email,
+  });
+
+  /** 字段级验证错误 */
+  const [fieldErrors, setFieldErrors] = useState<ProfileFormErrors>({});
+
+  /** 表单触碰状态 */
+  const [touched, setTouched] = useState<TouchedState>({
+    username: false,
+    email: false,
+  });
+
+  /** 提交状态 */
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  /** 提交级别的错误 */
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // ----------------------------------------------------------------------
+  // 验证逻辑
+  // ----------------------------------------------------------------------
+
+  /**
+   * 验证单个字段
+   */
+  const validateField = useCallback(
+    (field: keyof ProfileFormErrors, value: string) => {
+      let result;
+
+      if (field === 'username') {
+        result = ProfileValidator.validateUsername(value);
+      } else if (field === 'email') {
+        result = ProfileValidator.validateEmail(value);
+      } else {
+        return;
+      }
+
+      setFieldErrors((prev) => {
+        if (result.isValid) {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { [field]: _, ...rest } = prev;
+          return rest;
+        }
+        return { ...prev, [field]: result.error };
+      });
+    },
+    []
+  );
+
+  /**
+   * 验证整个表单
+   */
+  const validateForm = useCallback((): boolean => {
+    const result = ProfileValidator.validateForm(formData);
+
+    const errors: ProfileFormErrors = {};
+    if (!result.username.isValid) {
+      errors.username = result.username.error;
+    }
+    if (!result.email.isValid) {
+      errors.email = result.email.error;
+    }
+
+    setFieldErrors(errors);
+    return result.isValid;
+  }, [formData]);
+
+  // ----------------------------------------------------------------------
+  // 事件处理
+  // ----------------------------------------------------------------------
+
+  /**
+   * 字段变更处理
+   */
+  const handleFieldChange = (
+    field: keyof typeof touched,
+    value: string
+  ) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+
+    // 如果字段已被触碰，实时验证
+    if (touched[field]) {
+      validateField(field, value);
+    }
+
+    // 清除提交错误
+    if (submitError) {
+      setSubmitError(null);
+    }
+  };
+
+  /**
+   * 字段失焦处理
+   */
+  const handleFieldBlur = (field: keyof typeof touched) => {
+    setTouched((prev) => ({ ...prev, [field]: true }));
+    validateField(field, formData[field]);
+  };
+
+  /**
+   * 表单提交处理
+   */
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    // 清除提交错误
+    setSubmitError(null);
+
+    // 标记所有字段为已触碰
+    setTouched({ username: true, email: true });
+
+    // 验证表单
+    if (!validateForm()) {
+      return;
+    }
+
+    // 检查是否有变更
+    if (!ProfileValidator.hasChanges(originalData, formData)) {
+      setSubmitError('没有检测到任何变更');
+      return;
+    }
+
+    // 设置提交状态
+    setIsSubmitting(true);
+
+    try {
+      // 构建更新请求（只包含有变更的字段）
+      const updateData: { username?: string; email?: string } = {};
+      if (formData.username !== originalData.username) {
+        updateData.username = formData.username;
+      }
+      if (formData.email !== originalData.email) {
+        updateData.email = formData.email;
+      }
+
+      // 调用 API
+      const updatedUser = await authApi.updateProfile(updateData);
+
+      // 更新 authStore.user
+      const state = store.getState();
+      if (state.accessToken && state.refreshToken) {
+        store.setAuthUser(
+          updatedUser,
+          state.accessToken,
+          state.refreshToken,
+          Math.floor((state.tokenExpiresAt ?? Date.now()) / 1000) - Math.floor(Date.now() / 1000)
+        );
+      }
+
+      // 触发成功回调
+      onSuccess?.(updatedUser);
+    } catch (error) {
+      // 解析错误并生成友好的错误消息
+      let errorMessage: string;
+
+      if (error instanceof Error) {
+        const err = error as Error & { status?: number; field?: string };
+        const status = err.status;
+        const field = err.field;
+
+        if (status === 409) {
+          // 冲突错误 - 用户名或邮箱已存在
+          if (field === 'username') {
+            errorMessage = '该用户名已被使用';
+          } else if (field === 'email') {
+            errorMessage = '该邮箱已被注册';
+          } else {
+            errorMessage = '用户名或邮箱已存在';
+          }
+        } else if (status === 401) {
+          // 未认证
+          errorMessage = '请先登录后再试';
+        } else if (status === 400) {
+          // 验证错误
+          errorMessage = '输入信息格式不正确，请检查后重试';
+        } else if (err.name === 'NetworkError' || err.message.includes('network') || err.message.includes('Network')) {
+          // 网络错误
+          errorMessage = '网络连接失败，请稍后重试';
+        } else {
+          // 其他错误
+          errorMessage = err.message || '更新失败，请稍后重试';
+        }
+      } else {
+        errorMessage = '更新失败，请稍后重试';
+      }
+
+      setSubmitError(errorMessage);
+      onError?.(error instanceof Error ? error : new Error(errorMessage));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  /**
+   * 取消编辑处理
+   */
+  const handleCancel = () => {
+    // 恢复原始数据
+    setFormData(originalData);
+    // 清除错误
+    setFieldErrors({});
+    setTouched({ username: false, email: false });
+    setSubmitError(null);
+    // 触发取消回调
+    onCancel?.();
+  };
+
+  // ----------------------------------------------------------------------
+  // 渲染
+  // ----------------------------------------------------------------------
+
+  /** 计算是否有变更 */
+  const hasChanges = ProfileValidator.hasChanges(originalData, formData);
+
+  /** 计算表单是否有效 */
+  const isFormValid =
+    formData.username !== '' &&
+    formData.email !== '' &&
+    Object.keys(fieldErrors).length === 0 &&
+    hasChanges;
+
+  return (
+    <form
+      role="form"
+      aria-labelledby="profile-form-title"
+      onSubmit={handleSubmit}
+      noValidate
+      className={cn('profile-form', className)}
+    >
+      {/* 表单标题 */}
+      <h2 id="profile-form-title" className="profile-form-title">
+        编辑资料
+      </h2>
+
+      {/* 用户名输入框 */}
+      <Input
+        id="profile-username"
+        label="用户名"
+        type="text"
+        value={formData.username}
+        onChange={(e) => handleFieldChange('username', e.target.value)}
+        onBlur={() => handleFieldBlur('username')}
+        error={touched.username ? fieldErrors.username : undefined}
+        disabled={isSubmitting}
+        autoComplete="username"
+        data-testid="profile-username-input"
+      />
+
+      {/* 邮箱输入框 */}
+      <Input
+        id="profile-email"
+        label="邮箱"
+        type="email"
+        value={formData.email}
+        onChange={(e) => handleFieldChange('email', e.target.value)}
+        onBlur={() => handleFieldBlur('email')}
+        error={touched.email ? fieldErrors.email : undefined}
+        disabled={isSubmitting}
+        autoComplete="email"
+        data-testid="profile-email-input"
+      />
+
+      {/* 提交错误提示 */}
+      {submitError && (
+        <Alert type="error" showIcon closable onClose={() => setSubmitError(null)}>
+          {submitError}
+        </Alert>
+      )}
+
+      {/* 操作按钮 */}
+      <div className="profile-form-actions">
+        <Button
+          type="submit"
+          variant="primary"
+          disabled={!isFormValid || isSubmitting}
+          data-testid="profile-submit-btn"
+        >
+          {isSubmitting ? '保存中...' : '保存'}
+        </Button>
+
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={handleCancel}
+          disabled={isSubmitting}
+          data-testid="profile-cancel-btn"
+        >
+          取消
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/profile/UserInfoCard.tsx
+++ b/frontend/src/components/profile/UserInfoCard.tsx
@@ -1,0 +1,147 @@
+/**
+ * 用户信息展示卡片组件
+ *
+ * 功能:
+ * - 展示用户基本信息 (用户名、邮箱、注册时间、ID、状态)
+ * - 提供编辑按钮切换到编辑模式
+ * - 支持加载状态和骨架屏
+ *
+ * @module frontend/src/components/profile/UserInfoCard
+ */
+
+import type { UserResponse } from '@/types/auth';
+import { Card } from '@/components/ui';
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// 类型定义
+// ============================================================================
+
+/**
+ * UserInfoCard Props
+ */
+export interface UserInfoCardProps {
+  /** 用户信息 */
+  user: UserResponse;
+  /** 是否处于编辑模式 */
+  isEditing?: boolean;
+  /** 编辑按钮点击回调 */
+  onEditClick?: () => void;
+  /** 自定义类名 */
+  className?: string;
+}
+
+// ============================================================================
+// 辅助函数
+// ============================================================================
+
+/**
+ * 格式化日期显示
+ * @param dateString - ISO 日期字符串
+ * @returns 格式化后的日期字符串
+ */
+function formatDate(dateString: string): string {
+  try {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('zh-CN', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  } catch {
+    return dateString;
+  }
+}
+
+/**
+ * 获取用户名首字母（用于头像占位）
+ * @param username - 用户名
+ * @returns 首字母（大写）
+ */
+function getInitial(username: string): string {
+  return username.charAt(0).toUpperCase();
+}
+
+// ============================================================================
+// 组件实现
+// ============================================================================
+
+/**
+ * 用户信息展示卡片
+ *
+ * @example
+ * ```tsx
+ * <UserInfoCard
+ *   user={authStore.user}
+ *   isEditing={false}
+ *   onEditClick={() => setIsEditing(true)}
+ * />
+ * ```
+ */
+export function UserInfoCard({
+  user,
+  isEditing = false,
+  onEditClick,
+  className,
+}: UserInfoCardProps): JSX.Element {
+  return (
+    <Card className={cn('user-info-card', className)}>
+      <div className="user-info-card-content">
+        {/* 用户头像占位 */}
+        <div className="user-avatar-placeholder" aria-hidden="true">
+          <span className="user-avatar-initial">{getInitial(user.username)}</span>
+        </div>
+
+        {/* 用户信息 */}
+        <div className="user-info-details">
+          <div className="user-info-field">
+            <span className="user-info-label">用户 ID</span>
+            <span className="user-info-value" data-testid="user-id">
+              {user.id}
+            </span>
+          </div>
+
+          <div className="user-info-field">
+            <span className="user-info-label">用户名</span>
+            <span className="user-info-value" data-testid="user-username">
+              {user.username}
+            </span>
+          </div>
+
+          <div className="user-info-field">
+            <span className="user-info-label">邮箱</span>
+            <span className="user-info-value" data-testid="user-email">
+              {user.email}
+            </span>
+          </div>
+
+          <div className="user-info-field">
+            <span className="user-info-label">注册时间</span>
+            <span className="user-info-value" data-testid="user-created-at">
+              {formatDate(user.created_at)}
+            </span>
+          </div>
+
+          <div className="user-info-field">
+            <span className="user-info-label">状态</span>
+            <span className="user-info-value" data-testid="user-status">
+              {user.is_active ? '活跃' : '未激活'}
+            </span>
+          </div>
+        </div>
+
+        {/* 编辑按钮 */}
+        {!isEditing && (
+          <button
+            type="button"
+            className="user-info-edit-btn"
+            onClick={onEditClick}
+            aria-label="编辑资料"
+          >
+            编辑资料
+          </button>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/profile/__tests__/ProfileForm.test.tsx
+++ b/frontend/src/components/profile/__tests__/ProfileForm.test.tsx
@@ -1,0 +1,766 @@
+/**
+ * ProfileForm 组件单元测试
+ *
+ * 测试覆盖范围：
+ * - 基础渲染（表单字段、按钮）
+ * - 表单初始化（用户数据预填充）
+ * - 字段验证（客户端验证）
+ * - 提交成功（API 调用、状态更新）
+ * - 提交失败（错误处理）
+ * - 取消编辑（恢复原始数据）
+ * - 加载状态
+ * - 可访问性
+ *
+ * 基于蓝图设计：
+ * - /workspace/docs/blueprints/profile-page-blueprint.md
+ *
+ * 测试状态: RED (等待实现)
+ * 依赖文件: /workspace/frontend/src/components/profile/ProfileForm.tsx
+ *
+ * @jest-environment jsdom
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ============================================================================
+// 类型定义 (与蓝图保持一致)
+// ============================================================================
+
+interface UserResponse {
+  id: number;
+  username: string;
+  email: string;
+  is_active: boolean;
+  created_at: string;
+}
+
+interface UserUpdateRequest {
+  username?: string;
+  email?: string;
+}
+
+interface AuthApi {
+  updateProfile: jest.Mock;
+}
+
+interface AuthStore {
+  user: UserResponse | null;
+  setAuthUser: jest.Mock;
+}
+
+// ============================================================================
+// Mock 工厂函数
+// ============================================================================
+
+/**
+ * 创建 Mock UserResponse
+ */
+const createMockUser = (overrides?: Partial<UserResponse>): UserResponse => ({
+  id: 1,
+  username: 'testuser',
+  email: 'test@example.com',
+  is_active: true,
+  created_at: '2024-01-01T00:00:00Z',
+  ...overrides,
+});
+
+/**
+ * 创建 Mock AuthApi
+ */
+const createMockAuthApi = (): AuthApi => ({
+  updateProfile: jest.fn(),
+});
+
+/**
+ * 创建 Mock AuthStore
+ */
+const createMockAuthStore = (): AuthStore => ({
+  user: createMockUser(),
+  setAuthUser: jest.fn(),
+});
+
+/**
+ * 创建更新成功响应
+ */
+const createMockUpdateResponse = (overrides?: Partial<UserResponse>): UserResponse => ({
+  id: 1,
+  username: 'newuser',
+  email: 'new@example.com',
+  is_active: true,
+  created_at: '2024-01-01T00:00:00Z',
+  ...overrides,
+});
+
+// ============================================================================
+// 测试套件
+// ============================================================================
+
+describe('ProfileForm - 基础渲染', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('应该渲染表单', () => {
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+
+    render(<ProfileForm user={user} />);
+
+    expect(screen.getByRole('form')).toBeInTheDocument();
+  });
+
+  it('应该渲染用户名输入框', () => {
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+
+    render(<ProfileForm user={user} />);
+
+    expect(screen.getByLabelText(/^用户名$/)).toBeInTheDocument();
+  });
+
+  it('应该渲染邮箱输入框', () => {
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+
+    render(<ProfileForm user={user} />);
+
+    expect(screen.getByLabelText(/^邮箱$/)).toBeInTheDocument();
+  });
+
+  it('应该渲染保存按钮', () => {
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+
+    render(<ProfileForm user={user} />);
+
+    expect(screen.getByRole('button', { name: /保存/ })).toBeInTheDocument();
+  });
+
+  it('应该渲染取消按钮', () => {
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+
+    render(<ProfileForm user={user} />);
+
+    expect(screen.getByRole('button', { name: /取消/ })).toBeInTheDocument();
+  });
+
+  it('应该应用自定义 className', () => {
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+
+    const { container } = render(
+      <ProfileForm user={user} className="custom-form-class" />
+    );
+
+    expect(container.querySelector('.custom-form-class')).toBeInTheDocument();
+  });
+});
+
+describe('ProfileForm - 表单初始化', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('应该用用户数据预填充用户名', () => {
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser({ username: 'initialuser' });
+
+    render(<ProfileForm user={user} />);
+
+    const usernameInput = screen.getByLabelText(/^用户名$/);
+    expect(usernameInput).toHaveValue('initialuser');
+  });
+
+  it('应该用用户数据预填充邮箱', () => {
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser({ email: 'initial@example.com' });
+
+    render(<ProfileForm user={user} />);
+
+    const emailInput = screen.getByLabelText(/^邮箱$/);
+    expect(emailInput).toHaveValue('initial@example.com');
+  });
+
+  it('应该正确初始化不同的用户数据', () => {
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser({
+      username: 'anotheruser',
+      email: 'another@test.com',
+    });
+
+    render(<ProfileForm user={user} />);
+
+    expect(screen.getByLabelText(/^用户名$/)).toHaveValue('anotheruser');
+    expect(screen.getByLabelText(/^邮箱$/)).toHaveValue('another@test.com');
+  });
+});
+
+describe('ProfileForm - 字段验证', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('空用户名应该显示验证错误', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+
+    render(<ProfileForm user={user} authApi={mockAuthApi} />);
+
+    const usernameInput = screen.getByLabelText(/^用户名$/);
+    await userEventSetup.clear(usernameInput);
+
+    const saveButton = screen.getByRole('button', { name: /保存/ });
+    await userEventSetup.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/用户名不能为空/)).toBeInTheDocument();
+    });
+  });
+
+  it('太短的用户名应该显示验证错误', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+
+    render(<ProfileForm user={user} authApi={mockAuthApi} />);
+
+    const usernameInput = screen.getByLabelText(/^用户名$/);
+    await userEventSetup.clear(usernameInput);
+    await userEventSetup.type(usernameInput, 'ab');
+
+    const saveButton = screen.getByRole('button', { name: /保存/ });
+    await userEventSetup.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/用户名长度应为 3-50 个字符/)).toBeInTheDocument();
+    });
+  });
+
+  it('无效邮箱格式应该显示验证错误', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+
+    render(<ProfileForm user={user} authApi={mockAuthApi} />);
+
+    const emailInput = screen.getByLabelText(/^邮箱$/);
+    await userEventSetup.clear(emailInput);
+    await userEventSetup.type(emailInput, 'invalid-email');
+
+    const saveButton = screen.getByRole('button', { name: /保存/ });
+    await userEventSetup.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/邮箱格式不正确/)).toBeInTheDocument();
+    });
+  });
+
+  it('空邮箱应该显示验证错误', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+
+    render(<ProfileForm user={user} authApi={mockAuthApi} />);
+
+    const emailInput = screen.getByLabelText(/^邮箱$/);
+    await userEventSetup.clear(emailInput);
+
+    const saveButton = screen.getByRole('button', { name: /保存/ });
+    await userEventSetup.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/邮箱不能为空/)).toBeInTheDocument();
+    });
+  });
+
+  it('没有变更时不应该允许提交', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+
+    render(<ProfileForm user={user} authApi={mockAuthApi} />);
+
+    // 不修改任何字段，直接点击保存
+    const saveButton = screen.getByRole('button', { name: /保存/ });
+    await userEventSetup.click(saveButton);
+
+    // 不应该调用 API
+    expect(mockAuthApi.updateProfile).not.toHaveBeenCalled();
+  });
+});
+
+describe('ProfileForm - 提交成功场景', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('有效表单应该调用 authApi.updateProfile()', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+    const mockResponse = createMockUpdateResponse({ username: 'newuser' });
+
+    mockAuthApi.updateProfile.mockResolvedValue(mockResponse);
+
+    render(<ProfileForm user={user} authApi={mockAuthApi} />);
+
+    const usernameInput = screen.getByLabelText(/^用户名$/);
+    await userEventSetup.clear(usernameInput);
+    await userEventSetup.type(usernameInput, 'newuser');
+
+    await userEventSetup.click(screen.getByRole('button', { name: /保存/ }));
+
+    await waitFor(() => {
+      expect(mockAuthApi.updateProfile).toHaveBeenCalledWith({
+        username: 'newuser',
+      });
+    });
+  });
+
+  it('更新成功后应该调用 onSuccess 回调', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+    const onSuccess = jest.fn();
+    const mockResponse = createMockUpdateResponse({ username: 'newuser' });
+
+    mockAuthApi.updateProfile.mockResolvedValue(mockResponse);
+
+    render(
+      <ProfileForm
+        user={user}
+        authApi={mockAuthApi}
+        onSuccess={onSuccess}
+      />
+    );
+
+    const usernameInput = screen.getByLabelText(/^用户名$/);
+    await userEventSetup.clear(usernameInput);
+    await userEventSetup.type(usernameInput, 'newuser');
+
+    await userEventSetup.click(screen.getByRole('button', { name: /保存/ }));
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith(mockResponse);
+    });
+  });
+
+  it('更新邮箱成功后应该调用 updateProfile', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+    const mockResponse = createMockUpdateResponse({ email: 'new@example.com' });
+
+    mockAuthApi.updateProfile.mockResolvedValue(mockResponse);
+
+    render(<ProfileForm user={user} authApi={mockAuthApi} />);
+
+    const emailInput = screen.getByLabelText(/^邮箱$/);
+    await userEventSetup.clear(emailInput);
+    await userEventSetup.type(emailInput, 'new@example.com');
+
+    await userEventSetup.click(screen.getByRole('button', { name: /保存/ }));
+
+    await waitFor(() => {
+      expect(mockAuthApi.updateProfile).toHaveBeenCalledWith({
+        email: 'new@example.com',
+      });
+    });
+  });
+
+  it('同时更新用户名和邮箱', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+    const mockResponse = createMockUpdateResponse({
+      username: 'newuser',
+      email: 'new@example.com',
+    });
+
+    mockAuthApi.updateProfile.mockResolvedValue(mockResponse);
+
+    render(<ProfileForm user={user} authApi={mockAuthApi} />);
+
+    const usernameInput = screen.getByLabelText(/^用户名$/);
+    await userEventSetup.clear(usernameInput);
+    await userEventSetup.type(usernameInput, 'newuser');
+
+    const emailInput = screen.getByLabelText(/^邮箱$/);
+    await userEventSetup.clear(emailInput);
+    await userEventSetup.type(emailInput, 'new@example.com');
+
+    await userEventSetup.click(screen.getByRole('button', { name: /保存/ }));
+
+    await waitFor(() => {
+      expect(mockAuthApi.updateProfile).toHaveBeenCalledWith({
+        username: 'newuser',
+        email: 'new@example.com',
+      });
+    });
+  });
+});
+
+describe('ProfileForm - 提交失败场景', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('应该处理用户名已存在的错误 (409)', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+
+    const error = new Error('Username already exists');
+    (error as any).status = 409;
+    (error as any).field = 'username';
+    mockAuthApi.updateProfile.mockRejectedValue(error);
+
+    render(<ProfileForm user={user} authApi={mockAuthApi} />);
+
+    const usernameInput = screen.getByLabelText(/^用户名$/);
+    await userEventSetup.clear(usernameInput);
+    await userEventSetup.type(usernameInput, 'existinguser');
+
+    await userEventSetup.click(screen.getByRole('button', { name: /保存/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/用户名.*已被使用|已存在/)).toBeInTheDocument();
+    });
+  });
+
+  it('应该处理邮箱已存在的错误 (409)', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+
+    const error = new Error('Email already exists');
+    (error as any).status = 409;
+    (error as any).field = 'email';
+    mockAuthApi.updateProfile.mockRejectedValue(error);
+
+    render(<ProfileForm user={user} authApi={mockAuthApi} />);
+
+    const emailInput = screen.getByLabelText(/^邮箱$/);
+    await userEventSetup.clear(emailInput);
+    await userEventSetup.type(emailInput, 'existing@example.com');
+
+    await userEventSetup.click(screen.getByRole('button', { name: /保存/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/该邮箱已被注册/)).toBeInTheDocument();
+    });
+  });
+
+  it('应该处理未认证错误 (401)', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+
+    const error = new Error('Not authenticated');
+    (error as any).status = 401;
+    mockAuthApi.updateProfile.mockRejectedValue(error);
+
+    render(<ProfileForm user={user} authApi={mockAuthApi} />);
+
+    const usernameInput = screen.getByLabelText(/^用户名$/);
+    await userEventSetup.clear(usernameInput);
+    await userEventSetup.type(usernameInput, 'newuser');
+
+    await userEventSetup.click(screen.getByRole('button', { name: /保存/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/请先登录|未认证/)).toBeInTheDocument();
+    });
+  });
+
+  it('应该处理验证错误 (400)', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+
+    const error = new Error('Validation error');
+    (error as any).status = 400;
+    mockAuthApi.updateProfile.mockRejectedValue(error);
+
+    render(<ProfileForm user={user} authApi={mockAuthApi} />);
+
+    const usernameInput = screen.getByLabelText(/^用户名$/);
+    await userEventSetup.clear(usernameInput);
+    await userEventSetup.type(usernameInput, 'newuser');
+
+    await userEventSetup.click(screen.getByRole('button', { name: /保存/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/验证|格式/)).toBeInTheDocument();
+    });
+  });
+
+  it('应该处理网络错误', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+
+    const error = new Error('Network error');
+    error.name = 'NetworkError';
+    mockAuthApi.updateProfile.mockRejectedValue(error);
+
+    render(<ProfileForm user={user} authApi={mockAuthApi} />);
+
+    const usernameInput = screen.getByLabelText(/^用户名$/);
+    await userEventSetup.clear(usernameInput);
+    await userEventSetup.type(usernameInput, 'newuser');
+
+    await userEventSetup.click(screen.getByRole('button', { name: /保存/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/网络|连接/)).toBeInTheDocument();
+    });
+  });
+
+  it('应该调用 onError 回调', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+    const onError = jest.fn();
+
+    const error = new Error('Update failed');
+    mockAuthApi.updateProfile.mockRejectedValue(error);
+
+    render(
+      <ProfileForm
+        user={user}
+        authApi={mockAuthApi}
+        onError={onError}
+      />
+    );
+
+    const usernameInput = screen.getByLabelText(/^用户名$/);
+    await userEventSetup.clear(usernameInput);
+    await userEventSetup.type(usernameInput, 'newuser');
+
+    await userEventSetup.click(screen.getByRole('button', { name: /保存/ }));
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(error);
+    });
+  });
+});
+
+describe('ProfileForm - 取消编辑', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('点击取消按钮应该调用 onCancel 回调', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const onCancel = jest.fn();
+
+    render(<ProfileForm user={user} onCancel={onCancel} />);
+
+    const cancelButton = screen.getByRole('button', { name: /取消/ });
+    await userEventSetup.click(cancelButton);
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('取消后应该恢复原始数据', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser({ username: 'originaluser' });
+
+    render(<ProfileForm user={user} />);
+
+    // 修改用户名
+    const usernameInput = screen.getByLabelText(/^用户名$/);
+    await userEventSetup.clear(usernameInput);
+    await userEventSetup.type(usernameInput, 'modifieduser');
+
+    // 点击取消
+    const cancelButton = screen.getByRole('button', { name: /取消/ });
+    await userEventSetup.click(cancelButton);
+
+    // 数据应该恢复（如果组件仍然显示）
+    // 注：实际行为取决于 onCancel 是否导致组件卸载
+  });
+
+  it('取消后应该清除验证错误', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+
+    render(<ProfileForm user={user} authApi={mockAuthApi} />);
+
+    // 输入无效数据触发验证错误
+    const usernameInput = screen.getByLabelText(/^用户名$/);
+    await userEventSetup.clear(usernameInput);
+    await userEventSetup.type(usernameInput, 'ab');
+
+    // 点击取消
+    const cancelButton = screen.getByRole('button', { name: /取消/ });
+    await userEventSetup.click(cancelButton);
+
+    // 验证错误应该被清除
+    expect(screen.queryByText(/用户名长度/)).not.toBeInTheDocument();
+  });
+});
+
+describe('ProfileForm - 加载状态', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('提交时应该显示加载状态', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+
+    mockAuthApi.updateProfile.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve(createMockUpdateResponse()), 100))
+    );
+
+    render(<ProfileForm user={user} authApi={mockAuthApi} />);
+
+    const usernameInput = screen.getByLabelText(/^用户名$/);
+    await userEventSetup.clear(usernameInput);
+    await userEventSetup.type(usernameInput, 'newuser');
+
+    const saveButton = screen.getByRole('button', { name: /保存/ });
+    await userEventSetup.click(saveButton);
+
+    // 按钮应该被禁用或显示加载指示器
+    expect(saveButton).toBeDisabled();
+  });
+
+  it('提交完成后应该恢复可用状态', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+
+    mockAuthApi.updateProfile.mockResolvedValue(createMockUpdateResponse());
+
+    render(<ProfileForm user={user} authApi={mockAuthApi} />);
+
+    const usernameInput = screen.getByLabelText(/^用户名$/);
+    await userEventSetup.clear(usernameInput);
+    await userEventSetup.type(usernameInput, 'newuser');
+
+    const saveButton = screen.getByRole('button', { name: /保存/ });
+    await userEventSetup.click(saveButton);
+
+    await waitFor(() => {
+      expect(saveButton).not.toBeDisabled();
+    });
+  });
+
+  it('提交失败后应该恢复可用状态', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+
+    mockAuthApi.updateProfile.mockRejectedValue(new Error('Update failed'));
+
+    render(<ProfileForm user={user} authApi={mockAuthApi} />);
+
+    const usernameInput = screen.getByLabelText(/^用户名$/);
+    await userEventSetup.clear(usernameInput);
+    await userEventSetup.type(usernameInput, 'newuser');
+
+    const saveButton = screen.getByRole('button', { name: /保存/ });
+    await userEventSetup.click(saveButton);
+
+    await waitFor(() => {
+      expect(saveButton).not.toBeDisabled();
+    });
+  });
+});
+
+describe('ProfileForm - 可访问性', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('表单应该有正确的 ARIA 属性', () => {
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+
+    render(<ProfileForm user={user} />);
+
+    const form = screen.getByRole('form');
+    expect(form).toBeInTheDocument();
+  });
+
+  it('输入框应该有关联的 label', () => {
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+
+    render(<ProfileForm user={user} />);
+
+    expect(screen.getByLabelText(/^用户名$/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^邮箱$/)).toBeInTheDocument();
+  });
+
+  it('保存按钮应该有 type="submit"', () => {
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+
+    render(<ProfileForm user={user} />);
+
+    const saveButton = screen.getByRole('button', { name: /保存/ });
+    expect(saveButton).toHaveAttribute('type', 'submit');
+  });
+
+  it('取消按钮应该有 type="button"', () => {
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+
+    render(<ProfileForm user={user} />);
+
+    const cancelButton = screen.getByRole('button', { name: /取消/ });
+    expect(cancelButton).toHaveAttribute('type', 'button');
+  });
+
+  it('错误消息应该与输入框关联', async () => {
+    const userEventSetup = userEvent.setup();
+    const { ProfileForm } = require('../ProfileForm');
+    const user = createMockUser();
+    const mockAuthApi = createMockAuthApi();
+
+    render(<ProfileForm user={user} authApi={mockAuthApi} />);
+
+    const usernameInput = screen.getByLabelText(/^用户名$/);
+    await userEventSetup.clear(usernameInput);
+
+    const saveButton = screen.getByRole('button', { name: /保存/ });
+    await userEventSetup.click(saveButton);
+
+    await waitFor(() => {
+      const errorMessage = screen.getByText(/用户名不能为空/);
+      expect(errorMessage).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/profile/__tests__/UserInfoCard.test.tsx
+++ b/frontend/src/components/profile/__tests__/UserInfoCard.test.tsx
@@ -1,0 +1,293 @@
+/**
+ * UserInfoCard 组件单元测试
+ *
+ * 测试覆盖范围：
+ * - 基础渲染（用户信息展示）
+ * - 编辑按钮交互
+ * - 加载状态
+ * - 可访问性（ARIA 属性）
+ *
+ * 基于蓝图设计：
+ * - /workspace/docs/blueprints/profile-page-blueprint.md
+ *
+ * 测试状态: RED (等待实现)
+ * 依赖文件: /workspace/frontend/src/components/profile/UserInfoCard.tsx
+ *
+ * @jest-environment jsdom
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ============================================================================
+// 类型定义 (与蓝图保持一致)
+// ============================================================================
+
+interface UserResponse {
+  id: number;
+  username: string;
+  email: string;
+  is_active: boolean;
+  created_at: string;
+}
+
+// ============================================================================
+// Mock 工厂函数
+// ============================================================================
+
+/**
+ * 创建 Mock UserResponse
+ */
+const createMockUser = (overrides?: Partial<UserResponse>): UserResponse => ({
+  id: 1,
+  username: 'testuser',
+  email: 'test@example.com',
+  is_active: true,
+  created_at: '2024-01-01T00:00:00Z',
+  ...overrides,
+});
+
+// ============================================================================
+// 测试套件
+// ============================================================================
+
+describe('UserInfoCard - 基础渲染', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('应该渲染用户名', () => {
+    const { UserInfoCard } = require('../UserInfoCard');
+    const user = createMockUser();
+
+    render(<UserInfoCard user={user} />);
+
+    expect(screen.getByText('testuser')).toBeInTheDocument();
+  });
+
+  it('应该渲染邮箱地址', () => {
+    const { UserInfoCard } = require('../UserInfoCard');
+    const user = createMockUser();
+
+    render(<UserInfoCard user={user} />);
+
+    expect(screen.getByText('test@example.com')).toBeInTheDocument();
+  });
+
+  it('应该渲染注册时间', () => {
+    const { UserInfoCard } = require('../UserInfoCard');
+    const user = createMockUser();
+
+    render(<UserInfoCard user={user} />);
+
+    // 注册时间应该被格式化显示
+    expect(screen.getByText(/注册/)).toBeInTheDocument();
+  });
+
+  it('应该渲染用户 ID', () => {
+    const { UserInfoCard } = require('../UserInfoCard');
+    const user = createMockUser({ id: 42 });
+
+    render(<UserInfoCard user={user} />);
+
+    expect(screen.getByText(/42/)).toBeInTheDocument();
+  });
+
+  it('应该应用自定义 className', () => {
+    const { UserInfoCard } = require('../UserInfoCard');
+    const user = createMockUser();
+
+    const { container } = render(
+      <UserInfoCard user={user} className="custom-class" />
+    );
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});
+
+describe('UserInfoCard - 编辑按钮交互', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('非编辑模式下应该显示编辑按钮', () => {
+    const { UserInfoCard } = require('../UserInfoCard');
+    const user = createMockUser();
+
+    render(<UserInfoCard user={user} isEditing={false} />);
+
+    expect(screen.getByRole('button', { name: /编辑/ })).toBeInTheDocument();
+  });
+
+  it('编辑模式下应该隐藏编辑按钮', () => {
+    const { UserInfoCard } = require('../UserInfoCard');
+    const user = createMockUser();
+
+    render(<UserInfoCard user={user} isEditing={true} />);
+
+    expect(screen.queryByRole('button', { name: /编辑/ })).not.toBeInTheDocument();
+  });
+
+  it('点击编辑按钮应该触发 onEditClick 回调', async () => {
+    const userEventSetup = userEvent.setup();
+    const { UserInfoCard } = require('../UserInfoCard');
+    const user = createMockUser();
+    const onEditClick = jest.fn();
+
+    render(
+      <UserInfoCard
+        user={user}
+        isEditing={false}
+        onEditClick={onEditClick}
+      />
+    );
+
+    const editButton = screen.getByRole('button', { name: /编辑/ });
+    await userEventSetup.click(editButton);
+
+    expect(onEditClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('未提供 onEditClick 时编辑按钮不应该崩溃', async () => {
+    const userEventSetup = userEvent.setup();
+    const { UserInfoCard } = require('../UserInfoCard');
+    const user = createMockUser();
+
+    render(<UserInfoCard user={user} isEditing={false} />);
+
+    const editButton = screen.getByRole('button', { name: /编辑/ });
+    // 应该不会抛出错误
+    await userEventSetup.click(editButton);
+  });
+});
+
+describe('UserInfoCard - 数据展示', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('应该正确显示不同的用户名', () => {
+    const { UserInfoCard } = require('../UserInfoCard');
+    const user = createMockUser({ username: 'anotheruser' });
+
+    render(<UserInfoCard user={user} />);
+
+    expect(screen.getByText('anotheruser')).toBeInTheDocument();
+  });
+
+  it('应该正确显示不同的邮箱', () => {
+    const { UserInfoCard } = require('../UserInfoCard');
+    const user = createMockUser({ email: 'another@example.com' });
+
+    render(<UserInfoCard user={user} />);
+
+    expect(screen.getByText('another@example.com')).toBeInTheDocument();
+  });
+
+  it('应该正确格式化不同的注册时间', () => {
+    const { UserInfoCard } = require('../UserInfoCard');
+    const user = createMockUser({ created_at: '2024-06-15T10:30:00Z' });
+
+    render(<UserInfoCard user={user} />);
+
+    // 应该显示格式化后的日期
+    expect(screen.getByText(/2024/)).toBeInTheDocument();
+  });
+
+  it('应该显示用户状态（活跃）', () => {
+    const { UserInfoCard } = require('../UserInfoCard');
+    const user = createMockUser({ is_active: true });
+
+    render(<UserInfoCard user={user} />);
+
+    // 活跃用户可能显示状态指示器
+    expect(screen.getByText(/活跃|已激活|active/i)).toBeInTheDocument();
+  });
+
+  it('应该显示用户状态（非活跃）', () => {
+    const { UserInfoCard } = require('../UserInfoCard');
+    const user = createMockUser({ is_active: false });
+
+    render(<UserInfoCard user={user} />);
+
+    // 非活跃用户可能显示不同的状态
+    expect(screen.getByText(/未激活|inactive|已禁用/i)).toBeInTheDocument();
+  });
+});
+
+describe('UserInfoCard - 可访问性', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('卡片应该有正确的语义结构', () => {
+    const { UserInfoCard } = require('../UserInfoCard');
+    const user = createMockUser();
+
+    render(<UserInfoCard user={user} />);
+
+    // 应该使用卡片组件（article 或 section），或至少有卡片容器
+    const cardByRole = screen.queryByRole('article') || screen.queryByRole('region');
+    const cardByClass = document.querySelector('.user-info-card');
+
+    expect(cardByRole || cardByClass).toBeTruthy();
+  });
+
+  it('编辑按钮应该有可访问的标签', () => {
+    const { UserInfoCard } = require('../UserInfoCard');
+    const user = createMockUser();
+
+    render(<UserInfoCard user={user} isEditing={false} />);
+
+    const editButton = screen.getByRole('button', { name: /编辑/ });
+    expect(editButton).toHaveAttribute('aria-label');
+  });
+
+  it('用户信息应该有清晰的标签', () => {
+    const { UserInfoCard } = require('../UserInfoCard');
+    const user = createMockUser();
+
+    render(<UserInfoCard user={user} />);
+
+    // 用户名应该有关联的标签
+    expect(screen.getByText(/用户名|username/i)).toBeTruthy();
+    // 邮箱应该有关联的标签
+    expect(screen.getByText(/邮箱|email/i)).toBeTruthy();
+  });
+});
+
+describe('UserInfoCard - 边界条件', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('应该正确处理长用户名', () => {
+    const { UserInfoCard } = require('../UserInfoCard');
+    const longUsername = 'a'.repeat(50);
+    const user = createMockUser({ username: longUsername });
+
+    render(<UserInfoCard user={user} />);
+
+    expect(screen.getByText(longUsername)).toBeInTheDocument();
+  });
+
+  it('应该正确处理长邮箱地址', () => {
+    const { UserInfoCard } = require('../UserInfoCard');
+    const longEmail = 'very.long.email.address@subdomain.example.com';
+    const user = createMockUser({ email: longEmail });
+
+    render(<UserInfoCard user={user} />);
+
+    expect(screen.getByText(longEmail)).toBeInTheDocument();
+  });
+
+  it('应该正确处理特殊字符用户名', () => {
+    const { UserInfoCard } = require('../UserInfoCard');
+    const user = createMockUser({ username: 'user_name-123' });
+
+    render(<UserInfoCard user={user} />);
+
+    expect(screen.getByText('user_name-123')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/profile/index.ts
+++ b/frontend/src/components/profile/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Profile 组件统一导出
+ *
+ * @module frontend/src/components/profile
+ */
+
+export { UserInfoCard } from './UserInfoCard';
+export type { UserInfoCardProps } from './UserInfoCard';
+export { ProfileForm } from './ProfileForm';
+export type { ProfileFormProps } from './ProfileForm';

--- a/frontend/src/lib/api/__tests__/auth-api.test.ts
+++ b/frontend/src/lib/api/__tests__/auth-api.test.ts
@@ -38,6 +38,7 @@ const createMockHttpClient = (): HttpClient => ({
   post: jest.fn(),
   get: jest.fn(),
   put: jest.fn(),
+  patch: jest.fn(),
   delete: jest.fn(),
   request: jest.fn(),
 });
@@ -529,6 +530,185 @@ describe('AuthApi', () => {
       await expect(authApi.getCurrentUser()).rejects.toThrow(
         'Internal Server Error'
       );
+    });
+  });
+
+  // ==========================================================================
+  // updateProfile() - 成功场景
+  // ==========================================================================
+
+  describe('updateProfile()', () => {
+    it('should update profile successfully with username only', async () => {
+      // Arrange
+      const updateData = { username: 'newusername' };
+      const mockResponse = createMockUserResponse({ username: 'newusername' });
+
+      (mockHttpClient.patch as jest.Mock).mockResolvedValue(mockResponse);
+
+      // Act
+      const result = await authApi.updateProfile(updateData);
+
+      // Assert
+      expect(mockHttpClient.patch).toHaveBeenCalledTimes(1);
+      expect(mockHttpClient.patch).toHaveBeenCalledWith(
+        '/api/v1/auth/me',
+        updateData,
+        undefined
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should update profile successfully with email only', async () => {
+      // Arrange
+      const updateData = { email: 'new@example.com' };
+      const mockResponse = createMockUserResponse({ email: 'new@example.com' });
+
+      (mockHttpClient.patch as jest.Mock).mockResolvedValue(mockResponse);
+
+      // Act
+      const result = await authApi.updateProfile(updateData);
+
+      // Assert
+      expect(mockHttpClient.patch).toHaveBeenCalledWith(
+        '/api/v1/auth/me',
+        updateData,
+        undefined
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should update profile successfully with both username and email', async () => {
+      // Arrange
+      const updateData = {
+        username: 'newusername',
+        email: 'new@example.com',
+      };
+      const mockResponse = createMockUserResponse({
+        username: 'newusername',
+        email: 'new@example.com',
+      });
+
+      (mockHttpClient.patch as jest.Mock).mockResolvedValue(mockResponse);
+
+      // Act
+      const result = await authApi.updateProfile(updateData);
+
+      // Assert
+      expect(mockHttpClient.patch).toHaveBeenCalledWith(
+        '/api/v1/auth/me',
+        updateData,
+        undefined
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should return updated user response with all fields', async () => {
+      // Arrange
+      const updateData = { username: 'newuser' };
+      const mockResponse: UserResponse = {
+        id: 1,
+        username: 'newuser',
+        email: 'test@example.com',
+        is_active: true,
+        created_at: '2024-01-01T00:00:00Z',
+      };
+
+      (mockHttpClient.patch as jest.Mock).mockResolvedValue(mockResponse);
+
+      // Act
+      const result = await authApi.updateProfile(updateData);
+
+      // Assert
+      expect(result.id).toBe(1);
+      expect(result.username).toBe('newuser');
+      expect(result.email).toBe('test@example.com');
+      expect(result.is_active).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // updateProfile() - 失败场景
+  // ==========================================================================
+
+  describe('updateProfile() - Error Scenarios', () => {
+    it('should handle 400 bad request (validation error)', async () => {
+      // Arrange
+      const mockError = new Error('Validation error');
+      (mockError as any).status = 400;
+
+      (mockHttpClient.patch as jest.Mock).mockRejectedValue(mockError);
+
+      // Act & Assert
+      await expect(
+        authApi.updateProfile({ username: 'ab' })
+      ).rejects.toThrow('Validation error');
+    });
+
+    it('should handle 401 unauthorized error', async () => {
+      // Arrange
+      const mockError = new Error('Not authenticated');
+      (mockError as any).status = 401;
+
+      (mockHttpClient.patch as jest.Mock).mockRejectedValue(mockError);
+
+      // Act & Assert
+      await expect(
+        authApi.updateProfile({ username: 'newuser' })
+      ).rejects.toThrow('Not authenticated');
+    });
+
+    it('should handle 409 conflict (username already exists)', async () => {
+      // Arrange
+      const mockError = new Error('Username already exists');
+      (mockError as any).status = 409;
+      (mockError as any).field = 'username';
+
+      (mockHttpClient.patch as jest.Mock).mockRejectedValue(mockError);
+
+      // Act & Assert
+      await expect(
+        authApi.updateProfile({ username: 'existinguser' })
+      ).rejects.toThrow('Username already exists');
+    });
+
+    it('should handle 409 conflict (email already exists)', async () => {
+      // Arrange
+      const mockError = new Error('Email already exists');
+      (mockError as any).status = 409;
+      (mockError as any).field = 'email';
+
+      (mockHttpClient.patch as jest.Mock).mockRejectedValue(mockError);
+
+      // Act & Assert
+      await expect(
+        authApi.updateProfile({ email: 'existing@example.com' })
+      ).rejects.toThrow('Email already exists');
+    });
+
+    it('should handle network error', async () => {
+      // Arrange
+      const networkError = new Error('Network error');
+      networkError.name = 'NetworkError';
+
+      (mockHttpClient.patch as jest.Mock).mockRejectedValue(networkError);
+
+      // Act & Assert
+      await expect(
+        authApi.updateProfile({ username: 'newuser' })
+      ).rejects.toThrow('Network error');
+    });
+
+    it('should handle 500 server error', async () => {
+      // Arrange
+      const serverError = new Error('Internal Server Error');
+      (serverError as any).status = 500;
+
+      (mockHttpClient.patch as jest.Mock).mockRejectedValue(serverError);
+
+      // Act & Assert
+      await expect(
+        authApi.updateProfile({ username: 'newuser' })
+      ).rejects.toThrow('Internal Server Error');
     });
   });
 });

--- a/frontend/src/lib/api/auth-api.ts
+++ b/frontend/src/lib/api/auth-api.ts
@@ -17,7 +17,7 @@
 import type { HttpClient } from './client';
 import type { TokenStorage } from '@/lib/storage/token-storage';
 import type { TokenResponse, UserResponse } from '@/types/auth';
-import type { LoginResponse, RegisterResponse } from '@/types/auth';
+import type { LoginResponse, RegisterResponse, UserUpdateRequest, UserUpdateResponse } from '@/types/auth';
 import { setAuthToken } from '@/lib/storage/cookie-manager';
 
 /**
@@ -160,7 +160,7 @@ export class AuthApi {
     });
 
     // 更新 Cookie（供 Middleware 使用）
-    CookieManager.setAuthToken(
+    setAuthToken(
       response.access_token,
       response.expires_in
     );
@@ -179,6 +179,31 @@ export class AuthApi {
   async getCurrentUser(): Promise<UserResponse> {
     // 发送请求（需要认证，HttpClient 会自动注入 Token）
     return this.httpClient.get<UserResponse>('/api/v1/auth/me');
+  }
+
+  /**
+   * 更新当前用户资料
+   *
+   * 对应后端：PATCH /api/v1/auth/me
+   *
+   * @param data - 更新数据 (username 和/或 email)
+   * @returns 更新后的用户信息
+   * @throws {Error} 更新失败时抛出异常
+   *
+   * @example
+   * ```ts
+   * // 仅更新用户名
+   * const user = await authApi.updateProfile({ username: 'newname' });
+   *
+   * // 同时更新用户名和邮箱
+   * const user = await authApi.updateProfile({
+   *   username: 'newname',
+   *   email: 'new@email.com'
+   * });
+   * ```
+   */
+  async updateProfile(data: UserUpdateRequest): Promise<UserUpdateResponse> {
+    return this.httpClient.patch<UserUpdateResponse>('/api/v1/auth/me', data, undefined);
   }
 }
 

--- a/frontend/src/lib/validation/__tests__/profile-validation.test.ts
+++ b/frontend/src/lib/validation/__tests__/profile-validation.test.ts
@@ -1,0 +1,573 @@
+/**
+ * ProfileValidator 单元测试
+ *
+ * 测试覆盖范围：
+ * - 用户名验证（边界值 3-50、格式、错误消息）
+ * - 邮箱验证（格式、错误消息）
+ * - 完整表单验证
+ * - 表单变更检测
+ *
+ * 后端验证规则（参考 Issue #170）：
+ * - username: 3-50 字符, 字母数字下划线连字符
+ * - email: EmailStr 格式
+ *
+ * 测试状态: RED (等待实现)
+ * 依赖文件: /workspace/frontend/src/lib/validation/profile-validation.ts
+ *
+ * @jest-environment jsdom
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+// ============================================================================
+// 类型定义 (与蓝图保持一致)
+// ============================================================================
+
+interface FieldValidationResult {
+  isValid: boolean;
+  error?: string;
+}
+
+interface ProfileFormData {
+  username: string;
+  email: string;
+}
+
+interface ProfileFormValidation {
+  username: FieldValidationResult;
+  email: FieldValidationResult;
+  isValid: boolean;
+}
+
+// ============================================================================
+// 测试套件
+// ============================================================================
+
+describe('ProfileValidator - 用户名验证', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('边界值测试', () => {
+    it('应该拒绝空用户名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('');
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe('用户名不能为空');
+    });
+
+    it('应该拒绝少于 3 字符的用户名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('ab');
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe('用户名长度应为 3-50 个字符');
+    });
+
+    it('应该接受恰好 3 字符的用户名（边界值）', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('abc');
+
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('应该接受 50 字符的用户名（边界值）', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('a'.repeat(50));
+
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('应该拒绝超过 50 字符的用户名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('a'.repeat(51));
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe('用户名长度应为 3-50 个字符');
+    });
+  });
+
+  describe('格式验证', () => {
+    it('应该接受字母用户名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('username');
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('应该接受数字用户名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('user123');
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('应该接受下划线用户名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('user_name');
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('应该接受连字符用户名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('user-name');
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('应该接受混合格式用户名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('user_123-test');
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('应该拒绝空格用户名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('user name');
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toContain('格式');
+    });
+
+    it('应该拒绝特殊字符用户名 (@)', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('user@name');
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toContain('格式');
+    });
+
+    it('应该拒绝中文用户名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('用户名');
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toContain('格式');
+    });
+
+    it('应该接受以数字开头的用户名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('123user');
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('应该接受以下划线开头的用户名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('_username');
+
+      expect(result.isValid).toBe(true);
+    });
+  });
+
+  describe('错误消息', () => {
+    it('空用户名应该显示"用户名不能为空"', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('');
+
+      expect(result.error).toBe('用户名不能为空');
+    });
+
+    it('太短的用户名应该显示长度提示', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('ab');
+
+      expect(result.error).toBe('用户名长度应为 3-50 个字符');
+    });
+
+    it('太长的用户名应该显示长度提示', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('a'.repeat(51));
+
+      expect(result.error).toBe('用户名长度应为 3-50 个字符');
+    });
+
+    it('格式错误的用户名应该显示格式提示', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateUsername('user@name');
+
+      expect(result.error).toBe('用户名格式不正确，只能包含字母、数字、下划线和连字符');
+    });
+  });
+});
+
+describe('ProfileValidator - 邮箱验证', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('基本格式验证', () => {
+    it('应该拒绝空邮箱', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateEmail('');
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe('邮箱不能为空');
+    });
+
+    it('应该接受标准邮箱格式', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateEmail('user@example.com');
+
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('应该拒绝缺少 @ 的邮箱', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateEmail('userexample.com');
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe('邮箱格式不正确');
+    });
+
+    it('应该拒绝缺少域名的邮箱', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateEmail('user@');
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe('邮箱格式不正确');
+    });
+
+    it('应该拒绝缺少用户名的邮箱', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateEmail('@example.com');
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe('邮箱格式不正确');
+    });
+  });
+
+  describe('复杂邮箱格式', () => {
+    it('应该接受带子域名的邮箱', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateEmail('user@mail.example.com');
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('应该接受带数字的邮箱', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateEmail('user123@example.com');
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('应该接受带点号的邮箱用户名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateEmail('user.name@example.com');
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('应该接受带加号的邮箱', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateEmail('user+tag@example.com');
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('应该接受带连字符的邮箱用户名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateEmail('user-name@example.com');
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('应该接受带下划线的邮箱用户名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateEmail('user_name@example.com');
+
+      expect(result.isValid).toBe(true);
+    });
+  });
+
+  describe('无效格式', () => {
+    it('应该拒绝双 @ 符号的邮箱', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateEmail('user@@example.com');
+
+      expect(result.isValid).toBe(false);
+    });
+
+    it('应该拒绝以点号开头的域名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateEmail('user@.example.com');
+
+      expect(result.isValid).toBe(false);
+    });
+
+    it('应该拒绝以点号结尾的域名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateEmail('user@example.com.');
+
+      expect(result.isValid).toBe(false);
+    });
+
+    it('应该拒绝连续点号的域名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateEmail('user@example..com');
+
+      expect(result.isValid).toBe(false);
+    });
+  });
+
+  describe('错误消息', () => {
+    it('空邮箱应该显示"邮箱不能为空"', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateEmail('');
+
+      expect(result.error).toBe('邮箱不能为空');
+    });
+
+    it('格式错误的邮箱应该显示"邮箱格式不正确"', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const result = ProfileValidator.validateEmail('invalid-email');
+
+      expect(result.error).toBe('邮箱格式不正确');
+    });
+  });
+});
+
+describe('ProfileValidator - 完整表单验证', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('有效表单', () => {
+    it('应该接受完整的有效表单', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const formData: ProfileFormData = {
+        username: 'validuser',
+        email: 'user@example.com',
+      };
+
+      const result = ProfileValidator.validateForm(formData);
+
+      expect(result.isValid).toBe(true);
+      expect(result.username.isValid).toBe(true);
+      expect(result.email.isValid).toBe(true);
+    });
+
+    it('边界值有效表单应该通过（最小用户名）', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const formData: ProfileFormData = {
+        username: 'abc',  // 最小长度
+        email: 'user@example.com',
+      };
+
+      const result = ProfileValidator.validateForm(formData);
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('边界值有效表单应该通过（最大用户名）', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const formData: ProfileFormData = {
+        username: 'a'.repeat(50),  // 最大长度
+        email: 'user@example.com',
+      };
+
+      const result = ProfileValidator.validateForm(formData);
+
+      expect(result.isValid).toBe(true);
+    });
+  });
+
+  describe('无效表单', () => {
+    it('应该标记无效用户名', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const formData: ProfileFormData = {
+        username: 'ab',  // 太短
+        email: 'user@example.com',
+      };
+
+      const result = ProfileValidator.validateForm(formData);
+
+      expect(result.isValid).toBe(false);
+      expect(result.username.isValid).toBe(false);
+      expect(result.email.isValid).toBe(true);
+    });
+
+    it('应该标记无效邮箱', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const formData: ProfileFormData = {
+        username: 'validuser',
+        email: 'invalid-email',
+      };
+
+      const result = ProfileValidator.validateForm(formData);
+
+      expect(result.isValid).toBe(false);
+      expect(result.username.isValid).toBe(true);
+      expect(result.email.isValid).toBe(false);
+    });
+
+    it('应该标记所有无效字段', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const formData: ProfileFormData = {
+        username: 'ab',  // 太短
+        email: 'invalid-email',  // 无效格式
+      };
+
+      const result = ProfileValidator.validateForm(formData);
+
+      expect(result.isValid).toBe(false);
+      expect(result.username.isValid).toBe(false);
+      expect(result.email.isValid).toBe(false);
+    });
+  });
+
+  describe('错误消息收集', () => {
+    it('应该收集所有字段的错误消息', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const formData: ProfileFormData = {
+        username: '',
+        email: '',
+      };
+
+      const result = ProfileValidator.validateForm(formData);
+
+      expect(result.username.error).toBeDefined();
+      expect(result.email.error).toBeDefined();
+    });
+
+    it('有效字段不应该有错误消息', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const formData: ProfileFormData = {
+        username: 'validuser',
+        email: '',
+      };
+
+      const result = ProfileValidator.validateForm(formData);
+
+      expect(result.username.error).toBeUndefined();
+      expect(result.email.error).toBeDefined();
+    });
+  });
+});
+
+describe('ProfileValidator - 表单变更检测', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('hasChanges()', () => {
+    it('应该检测到用户名变更', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const original: ProfileFormData = {
+        username: 'olduser',
+        email: 'user@example.com',
+      };
+      const current: ProfileFormData = {
+        username: 'newuser',
+        email: 'user@example.com',
+      };
+
+      const result = ProfileValidator.hasChanges(original, current);
+
+      expect(result).toBe(true);
+    });
+
+    it('应该检测到邮箱变更', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const original: ProfileFormData = {
+        username: 'user',
+        email: 'old@example.com',
+      };
+      const current: ProfileFormData = {
+        username: 'user',
+        email: 'new@example.com',
+      };
+
+      const result = ProfileValidator.hasChanges(original, current);
+
+      expect(result).toBe(true);
+    });
+
+    it('应该检测到两个字段都有变更', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const original: ProfileFormData = {
+        username: 'olduser',
+        email: 'old@example.com',
+      };
+      const current: ProfileFormData = {
+        username: 'newuser',
+        email: 'new@example.com',
+      };
+
+      const result = ProfileValidator.hasChanges(original, current);
+
+      expect(result).toBe(true);
+    });
+
+    it('没有变更时应该返回 false', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const original: ProfileFormData = {
+        username: 'user',
+        email: 'user@example.com',
+      };
+      const current: ProfileFormData = {
+        username: 'user',
+        email: 'user@example.com',
+      };
+
+      const result = ProfileValidator.hasChanges(original, current);
+
+      expect(result).toBe(false);
+    });
+
+    it('应该对用户名大小写敏感', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const original: ProfileFormData = {
+        username: 'User',
+        email: 'user@example.com',
+      };
+      const current: ProfileFormData = {
+        username: 'user',
+        email: 'user@example.com',
+      };
+
+      const result = ProfileValidator.hasChanges(original, current);
+
+      expect(result).toBe(true);
+    });
+
+    it('应该对邮箱大小写敏感', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const original: ProfileFormData = {
+        username: 'user',
+        email: 'User@Example.com',
+      };
+      const current: ProfileFormData = {
+        username: 'user',
+        email: 'user@example.com',
+      };
+
+      const result = ProfileValidator.hasChanges(original, current);
+
+      expect(result).toBe(true);
+    });
+
+    it('应该对空格敏感', () => {
+      const { ProfileValidator } = require('../profile-validation');
+      const original: ProfileFormData = {
+        username: 'user',
+        email: 'user@example.com',
+      };
+      const current: ProfileFormData = {
+        username: 'user ',
+        email: 'user@example.com',
+      };
+
+      const result = ProfileValidator.hasChanges(original, current);
+
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/frontend/src/lib/validation/profile-validation.ts
+++ b/frontend/src/lib/validation/profile-validation.ts
@@ -1,0 +1,182 @@
+/**
+ * 用户资料验证规则
+ *
+ * 职责:
+ * - 定义用户名、邮箱的验证规则
+ * - 提供字段级验证方法
+ * - 与后端 Pydantic 验证规则保持一致
+ *
+ * @module frontend/src/lib/validation/profile-validation
+ */
+
+import type { ProfileFormData } from '@/types/auth';
+
+// ============================================================================
+// 类型定义
+// ============================================================================
+
+/**
+ * 字段验证结果
+ */
+export interface FieldValidationResult {
+  /** 是否有效 */
+  isValid: boolean;
+  /** 错误消息 (无效时存在) */
+  error?: string;
+}
+
+/**
+ * 用户资料表单验证结果
+ */
+export interface ProfileFormValidation {
+  /** 用户名验证结果 */
+  username: FieldValidationResult;
+  /** 邮箱验证结果 */
+  email: FieldValidationResult;
+  /** 整体表单是否有效 */
+  isValid: boolean;
+}
+
+// ============================================================================
+// 常量定义
+// ============================================================================
+
+/**
+ * 验证规则常量
+ */
+const VALIDATION_RULES = {
+  /** 用户名最小长度 */
+  USERNAME_MIN_LENGTH: 3,
+  /** 用户名最大长度 */
+  USERNAME_MAX_LENGTH: 50,
+} as const;
+
+/**
+ * 错误消息常量
+ */
+const ERROR_MESSAGES = {
+  USERNAME_REQUIRED: '用户名不能为空',
+  USERNAME_LENGTH: '用户名长度应为 3-50 个字符',
+  USERNAME_FORMAT: '用户名格式不正确，只能包含字母、数字、下划线和连字符',
+  EMAIL_REQUIRED: '邮箱不能为空',
+  EMAIL_INVALID: '邮箱格式不正确',
+} as const;
+
+/**
+ * 用户名正则表达式
+ * 与后端验证规则保持一致
+ */
+const USERNAME_REGEX = /^[a-zA-Z0-9_-]+$/;
+
+/**
+ * 邮箱正则表达式 (更严格的验证)
+ * - 用户名: 字母、数字、点、加号、连字符、下划线
+ * - @ 符号
+ * - 域名: 字母、数字、点、连字符 (不能以点开头/结尾，不能有连续点)
+ */
+const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/;
+
+// ============================================================================
+// 验证器类
+// ============================================================================
+
+/**
+ * 用户资料验证器
+ *
+ * 提供静态方法验证用户资料表单的各个字段
+ */
+export class ProfileValidator {
+  /**
+   * 验证用户名
+   *
+   * 规则:
+   * - 必填
+   * - 3-50 字符
+   * - 仅允许字母、数字、下划线、连字符
+   *
+   * @param username - 用户名
+   * @returns 验证结果
+   */
+  static validateUsername(username: string): FieldValidationResult {
+    // 检查必填
+    if (!username || username.trim() === '') {
+      return { isValid: false, error: ERROR_MESSAGES.USERNAME_REQUIRED };
+    }
+
+    const trimmed = username.trim();
+
+    // 检查长度
+    if (
+      trimmed.length < VALIDATION_RULES.USERNAME_MIN_LENGTH ||
+      trimmed.length > VALIDATION_RULES.USERNAME_MAX_LENGTH
+    ) {
+      return { isValid: false, error: ERROR_MESSAGES.USERNAME_LENGTH };
+    }
+
+    // 检查格式
+    if (!USERNAME_REGEX.test(trimmed)) {
+      return { isValid: false, error: ERROR_MESSAGES.USERNAME_FORMAT };
+    }
+
+    return { isValid: true };
+  }
+
+  /**
+   * 验证邮箱
+   *
+   * 规则:
+   * - 必填
+   * - 标准邮箱格式
+   *
+   * @param email - 邮箱地址
+   * @returns 验证结果
+   */
+  static validateEmail(email: string): FieldValidationResult {
+    // 检查必填
+    if (!email || email.trim() === '') {
+      return { isValid: false, error: ERROR_MESSAGES.EMAIL_REQUIRED };
+    }
+
+    const trimmed = email.trim();
+
+    // 检查格式
+    if (!EMAIL_REGEX.test(trimmed)) {
+      return { isValid: false, error: ERROR_MESSAGES.EMAIL_INVALID };
+    }
+
+    return { isValid: true };
+  }
+
+  /**
+   * 验证整个表单
+   *
+   * @param data - 表单数据
+   * @returns 表单验证结果
+   */
+  static validateForm(data: ProfileFormData): ProfileFormValidation {
+    const usernameResult = this.validateUsername(data.username);
+    const emailResult = this.validateEmail(data.email);
+
+    const isValid = usernameResult.isValid && emailResult.isValid;
+
+    return {
+      username: usernameResult,
+      email: emailResult,
+      isValid,
+    };
+  }
+
+  /**
+   * 检查表单数据是否有变更
+   *
+   * @param original - 原始数据
+   * @param current - 当前数据
+   * @returns 是否有变更
+   */
+  static hasChanges(
+    original: ProfileFormData,
+    current: ProfileFormData
+  ): boolean {
+    return original.username !== current.username || original.email !== current.email;
+  }
+}

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -131,3 +131,73 @@ export interface RefreshTokenRequest {
  * 与 TokenResponse 结构完全一致
  */
 export type RefreshTokenResponse = TokenResponse;
+
+// ============================================================================
+// 用户资料更新相关类型 (新增)
+// ============================================================================
+
+/**
+ * 用户资料更新请求模型
+ * 对应后端 UserUpdateRequest schema
+ */
+export interface UserUpdateRequest {
+  /** 用户名 (可选, 3-50 字符) */
+  username?: string;
+  /** 邮箱地址 (可选) */
+  email?: string;
+}
+
+/**
+ * 用户资料更新响应模型
+ * 对应后端 UserResponse schema (与 getCurrentUser 返回类型一致)
+ */
+export type UserUpdateResponse = UserResponse;
+
+/**
+ * 用户资料表单数据
+ * 用于 ProfileForm 组件内部状态管理
+ */
+export interface ProfileFormData {
+  /** 用户名 */
+  username: string;
+  /** 邮箱地址 */
+  email: string;
+}
+
+/**
+ * 用户资料表单错误
+ */
+export interface ProfileFormErrors {
+  /** 用户名错误 */
+  username?: string;
+  /** 邮箱错误 */
+  email?: string;
+}
+
+/**
+ * API 错误响应类型 (扩展现有定义)
+ */
+export interface ApiErrorResponse {
+  /** 错误详情 */
+  detail: string;
+  /** 冲突字段 (用于 409 错误) */
+  field?: 'username' | 'email';
+}
+
+/**
+ * 用户资料更新错误类型枚举
+ */
+export enum ProfileUpdateErrorType {
+  /** 用户名已存在 */
+  USERNAME_EXISTS = 'USERNAME_EXISTS',
+  /** 邮箱已存在 */
+  EMAIL_EXISTS = 'EMAIL_EXISTS',
+  /** 网络错误 */
+  NETWORK_ERROR = 'NETWORK_ERROR',
+  /** 验证错误 */
+  VALIDATION_ERROR = 'VALIDATION_ERROR',
+  /** 未认证 */
+  UNAUTHORIZED = 'UNAUTHORIZED',
+  /** 未知错误 */
+  UNKNOWN_ERROR = 'UNKNOWN_ERROR',
+}


### PR DESCRIPTION
## Summary
实现完整的用户资料页面功能，包括 API 扩展、UI 组件和页面集成。

### 功能概览
- 新增 `updateProfile()` API 方法对接后端 `PATCH /api/v1/auth/me`
- 创建 `UserInfoCard` 组件用于展示用户信息
- 创建 `ProfileForm` 组件用于编辑用户资料（含验证和错误处理）
- 创建 `/profile` 页面并使用 `withAuthGuard` 保护

### 变更详情
| 文件 | 变更类型 |
|------|----------|
| `types/auth.ts` | 新增 `UserUpdateRequest`/`UserUpdateResponse` 类型 |
| `auth-api.ts` | 新增 `updateProfile()` 方法 |
| `profile-validation.ts` | 表单验证逻辑 |
| `UserInfoCard.tsx` | 用户信息展示卡片 |
| `ProfileForm.tsx` | 资料编辑表单 |
| `page.tsx` | 用户资料页面 |

### 测试覆盖
- ✅ `profile-validation.test.ts` - 验证规则测试
- ✅ `UserInfoCard.test.tsx` - 组件渲染和交互测试
- ✅ `ProfileForm.test.tsx` - 表单验证和提交测试
- ✅ `auth-api.test.ts` - API 调用测试

### 子任务
- Closes #173 (前端 API 扩展)
- Closes #174 (UI 组件开发)
- Closes #175 (页面集成与测试)

Closes #171

## Test plan
- [x] 前端单元测试全部通过 (188 passed)
- [x] 后端单元测试全部通过 (1124 passed)
- [ ] E2E 测试将在 CI 中运行

🤖 Generated with [Claude Code](https://claude.com/claude-code)